### PR TITLE
Fix PlaceableObject#update deprecation warning

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -339,7 +339,7 @@ export default class ActorWfrp4e extends Actor {
       }
       else if (canvas) {
         this.data.token.update(tokenData)
-        this.getActiveTokens().forEach(t => t.update(tokenData));
+        this.getActiveTokens().forEach(t => t.document.update(tokenData));
       }
     }
 


### PR DESCRIPTION
I kept getting this while working on v8 updates to GM Toolkit macros.  
> foundry.js:19241 You are calling PlaceableObject#update which has been deprecated in favor of Document#update or Scene#updateEmbeddedDocuments. Support will be removed in 0.9.0 

To reproduce, update an actor that has a linked token in the viewed scene (eg, current Fortune directly via character sheet or Reset Fortune macro).  The deprecation warning comes up in console. 

