### PR TITLE
Fix error in adding flaws from _addProperties

### DIFF
--- a/modules/item/item-wfrp4e.js
+++ b/modules/item/item-wfrp4e.js
@@ -1295,7 +1295,7 @@ export default class ItemWfrp4e extends Item {
         hasQuality.value += properties.flaws[f].value
       }
       else
-        flaws.push({ name: q, value: properties.flaws[f].value })
+        flaws.push({ name: f, value: properties.flaws[f].value })
     }
   }
 


### PR DESCRIPTION
The variable in _addProperties was named incorrectly, which caused issues when selecting ammunition that contains a flaw. This flaw was not being properly transferred to the weapon.