### PR TITLE
Add error messages advancement functions to prevent negative xp

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -228,6 +228,7 @@
     "ACTOR.AddBasicSkills" : "Add Basic Skills",
     "ACTOR.ImportStatBlock" : "Import Stat Block",
     "ACTOR.SpentExp" : "Spent {amount} Experience on {reason}",
+    "ACTOR.AdvancementError": "Cannot afford to {action} {item}, not enough experience available",
     "ACTOR.ClearMount" : "Clear Mount",
 
     "ITEM.PenniesValue" : "Value (in d)",

--- a/modules/actor/sheet/character-sheet.js
+++ b/modules/actor/sheet/character-sheet.js
@@ -259,6 +259,10 @@ export default class ActorSheetWfrp4eCharacter extends ActorSheetWfrp4e {
               {
                 label: game.i18n.localize("Yes"),
                 callback: dlg => {
+                  if(this.actor.details.experience.total - (this.actor.details.experience.spent + 100) < 0) {
+                    ui.notifications.error(game.i18n.format("ACTOR.AdvancementError", { action: 'add', item: talent.name }));
+                    return;
+                  }
                   this.actor.createEmbeddedDocuments("Item", [talent.data]);
                   let expLog = duplicate(this.actor.details.experience.log || []) 
                   expLog.push({amount : 100, reason : talent.name, spent : this.actor.details.experience.spent + 100, total : this.actor.details.experience.total, type : "spent"})
@@ -306,6 +310,10 @@ export default class ActorSheetWfrp4eCharacter extends ActorSheetWfrp4e {
       if (ev.button == 0) {
         // Calculate the advancement cost based on the current number of advances, subtract that amount, advance by 1
         let cost = WFRP_Utility._calculateAdvCost(item.advances.value, type, item.advances.costModifier)
+        if(data.details.experience.total - (data.details.experience.spent + cost) < 0) {
+          ui.notifications.error(game.i18n.format("ACTOR.AdvancementError", { action: 'improve', item: item.name }));
+          return;
+        }
         data.details.experience.spent = Number(data.details.experience.spent) + cost;
         await item.update({"data.advances.value" : item.advances.value + 1})
 
@@ -335,6 +343,10 @@ export default class ActorSheetWfrp4eCharacter extends ActorSheetWfrp4e {
         let advances = item.Advances
         let spent = 0;
         let cost = (advances + 1) * 100
+        if(this.actor.details.experience.total - (this.actor.details.experience.spent + cost) < 0) {
+          ui.notifications.error(game.i18n.format("ACTOR.AdvancementError", { action: 'improve', item: item.name }));
+          return;
+        }
         if (advances < item.Max || item.Max == "-") {
           spent = this.actor.details.experience.spent + cost
         }
@@ -399,6 +411,10 @@ export default class ActorSheetWfrp4eCharacter extends ActorSheetWfrp4e {
       if (ev.button == 0) {
         // Calculate the advancement cost based on the current number of advances, subtract that amount, advance by 1
         let cost = WFRP_Utility._calculateAdvCost(currentChar.advances, "characteristic");
+        if(data.details.experience.total - (data.details.experience.spent + cost) < 0) {
+          ui.notifications.error(game.i18n.format("ACTOR.AdvancementError", { action: 'improve', item: game.wfrp4e.config.characteristics[characteristic] }));
+          return;
+        }
         data.characteristics[characteristic].advances++;
         data.details.experience.spent = Number(data.details.experience.spent) + cost;
 

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -1025,8 +1025,19 @@ export default class WFRP_Utility {
     })
   }
 
-
-
+  /*
+  * Checks that the selected advancement can be afforded by the actor
+  *
+  * @param {Integer} total: the xp total for the actor
+  * @param {Integer} spent: the spent xp plus cost
+  * @param {String} action: the action, buy or improve for example
+  * @param {String} item: the title of the skill, talent or characteristic
+  */
+  static checkValidAdvancement(total, spent, action, item) {
+    if(total - spent < 0) {
+       throw new Error(game.i18n.format("ACTOR.AdvancementError", { action: action, item: item }));
+    }
+  }
 
 
 


### PR DESCRIPTION
I've added some small code to prevent xp going into negative, also added a i18n message and ui errors to display on click. It's not my most DRY code, but I didn't want to go adding a function in the sheet. I could add it in the utility class if that works better for you?

```
static checkValidAdvancement(total, spent, action, item) {
  if(total - spent < 0) {
     ui.notifications.error(game.i18n.format("ACTOR.AdvancementError", { action: action, item: item }));
     return false;
  } else {
    return true;
  }
}
```

for example