### PR TITLE
Fixes #962 typo in javascript

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -69,7 +69,7 @@ export default class ActorWfrp4e extends Actor {
           "token.name": data.name                                       // Set token name to actor name
         })
     else if (data.token)
-      createDate.token = data.token
+      createData.token = data.token
 
     // Set custom default token
     if (!data.img) {


### PR DESCRIPTION
Fixes #962 typo in javascript referring to `createDate` when it should be `createData`.