### PR TITLE
Ref: #992 fix the insertion of the ref to the attacker message

### DIFF
--- a/modules/system/opposed-wfrp4e.js
+++ b/modules/system/opposed-wfrp4e.js
@@ -127,7 +127,7 @@ export default class OpposedWFRP {
       this.defenderMessage.update({ "flags.data.attackerMessage": this.attackerMessage.id });
     }
     else 
-      game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: this.defenderMessage.id, updateData: { "flags.data.attackerMessage": [this.attackerMessage.id] } } })
+      game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: this.defenderMessage.id, updateData: { "flags.data.attackerMessage": this.attackerMessage.id } } })
       
   }
 


### PR DESCRIPTION
The message.data.flags.data.attackerMessage returns an array (with one element) and not the final string with the message id.
This ends up failing to find the message in the map and the attackerMessage stays as undefined.
