### PR TITLE
Persist Charging option status in Trait Test data

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -1161,6 +1161,7 @@ export default class ActorWfrp4e extends Actor {
       rollClass: game.wfrp4e.rolls.TraitTest,
       item: trait.id || trait.toObject(),  // Store item data directly if unowned item (system item like unarmed)
       hitLocation: false,
+      charging: options.charging || false,
       champion: !!this.has(game.i18n.localize("NAME.Champion")),
       options: options,
       postFunction: "traitTest"
@@ -1183,6 +1184,7 @@ export default class ActorWfrp4e extends Actor {
         hitLocation: testData.hitLocation,
         talents: this.getTalentTests(),
         chargingOption: this.showCharging(trait),
+        charging: testData.charging,
         characteristicToUse: trait.rollable.rollCharacteristic,
         advantage: this.status.advantage.value || 0,
         dialogEffects: this.getDialogChoices()
@@ -1196,6 +1198,7 @@ export default class ActorWfrp4e extends Actor {
         testData.testDifficulty = game.wfrp4e.config.difficultyModifiers[html.find('[name="testDifficulty"]').val()];
         testData.successBonus = Number(html.find('[name="successBonus"]').val());
         testData.slBonus = Number(html.find('[name="slBonus"]').val());
+        testData.charging = html.find('[name="charging"]').is(':checked');
         testData.characteristicToUse = html.find('[name="characteristicToUse"]').val();
         testData.hitLocation = html.find('[name="hitLocation"]').is(':checked');
         testData.cardOptions = cardOptions;

--- a/modules/system/rolls/trait-test.js
+++ b/modules/system/rolls/trait-test.js
@@ -6,6 +6,7 @@ export default class TraitTest extends TestWFRP {
     super(data, actor)
     if (!data)
       return
+    this.preData.charging = data.charging || false;
     this.preData.champion = data.champion || false;
     this.preData.options.characteristicToUse = data.characteristicToUse
     this.computeTargetNumber();

--- a/modules/system/rolls/weapon-test.js
+++ b/modules/system/rolls/weapon-test.js
@@ -15,7 +15,6 @@ export default class WeaponTest extends TestWFRP {
     this.preData.riposte = data.riposte || false;
     this.preData.infighter = data.infighter || false;
     this.preData.resolute = data.resolute || 0;
-    this.preData.charging = data.charging || false;
     this.preData.dualWielding = data.dualWielding || false;
 
     this.computeTargetNumber();


### PR DESCRIPTION
Currently: 
- If the Charging checkbox is selected on a Weapon test, that selection is carried into the test / opposed test predata results.  
- This does not happen for Trait Tests where charging is an option.  
- In both cases the Advantage change for toggling Charging is applied as expected. 

This change: 
- passes the Charging checked status from Trait Test dialogs through to TraitTest results
- removes duplicate predata.charging reference in WeaponTest
