### PR TITLE
Sanitize chat message content

### DIFF
--- a/modules/hooks/chat.js
+++ b/modules/hooks/chat.js
@@ -285,7 +285,7 @@ export default function() {
   Hooks.on("createChatMessage", (msg, options) => {
 
     // If message has the opposed class signifying an opposed result
-    if ($(msg.data.content).find(".opposed-card").length && msg.data.flags.startMessageId && (game.user.isUniqueGM)) {
+    if ($((msg.data.content).escape).find(".opposed-card").length && msg.data.flags.startMessageId && (game.user.isUniqueGM)) {
       // Look in the flags for the winner and startMessage
       let winner = msg.data.flags.opposeData.opposeResult.winner;
       let startMessage = game.messages.get(msg.data.flags.startMessageId)


### PR DESCRIPTION
When a player enters a single or double quote in the chat message it generates an error.
This has the side effect to reveal whispers to anyone monitoring the errors in the console.

Escaping the string fixes the issue and doesn't seem to break other behaviors.
