### PR TITLE
Fixed Rest & Recover Wounds

### DIFF
--- a/modules/hooks/chat.js
+++ b/modules/hooks/chat.js
@@ -371,7 +371,7 @@ export default function() {
       woundsHealed.addEventListener('dragstart', ev => {
         let dataTransfer = {
           type : "wounds",
-          payload : app.data.flags.data.testData.result.woundsHealed
+          payload : app.data.flags.testData.result.woundsHealed
         }
         ev.dataTransfer.setData("text/plain", JSON.stringify(dataTransfer));
       })


### PR DESCRIPTION
This fixes the "Rest & Recover Wounds" button not recovering the wounds when dragging them from the chat.