### PR TITLE
Guard against undefined objects during encounters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
 debug.log
+wfrp4e.lock

--- a/modules/system/audio-wfrp4e.js
+++ b/modules/system/audio-wfrp4e.js
@@ -1,8 +1,10 @@
 export default class WFRP_Audio {
   static PlayContextAudio(context) {
     this.MatchContextAudio(context).then(sound => {
-      if (!sound)
+      if (!sound || !sound.file) {
+        console.warn("wfrp4e | Sound file not found for context: %o", context)
         return
+      }
       console.log(`wfrp4e | Playing Sound: ${sound.file}`)
       AudioHelper.play({ src: sound.file }, sound.global)
     })
@@ -56,7 +58,7 @@ export default class WFRP_Audio {
         context = { item: test.spell, action: "miscast" }
     }
     if (test.prayer) {
-      if (test.result.outcome == "success") 
+      if (test.result.outcome == "success")
         context = { item: test.prayer, action: "cast" }
 
       if (test.result.wrath)
@@ -81,8 +83,7 @@ export default class WFRP_Audio {
       return {}
 
     try {
-      let files = ""
-      let file, group;
+      let files, file, group;
       await FilePicker.browse("user", game.settings.get("wfrp4e", "soundPath")).then(resp => {
         files = resp.files
       })


### PR DESCRIPTION
Hello, learning to develop on this project. Starting simple by eliminating a couple of exceptions that I noticed.

1. When starting a combat encounter without a scene or tokens, undefined object exceptions fire in `CombatHelpers.startTurnChecks()` for the `turn` object and `CombatHelpers.checkEndTurnConditions()` for the `combatant` object. Added tests for undefined to prevent these exceptions, and write a console warning instead in `startTurnChecks()`.

2. Seems like all the sound files are removed from `sounds.txt`, so `WFRP_Audio.PlayContextAudio` by default always throws an undefined object and also causes an HTTP 404. Added test for undefined `sound.file` to prevent both of those in favor of a console warning.

3. Set git to ignore the `wfrp4e.lock` file if you happen to have the system locked in VTT.