### PR TITLE
Improve compatibility with Simple Calendar

### DIFF
--- a/css/wfrp4e.css
+++ b/css/wfrp4e.css
@@ -16505,7 +16505,7 @@ hr,
 .simple-calendar.classic .fsc-ya.fsc-qh {
     padding: 3px 3px 3px 3px;
     line-height: normal;
-    border: 3px double #736953a6;
+    border: 1px solid #736953a6;
     box-shadow: 0px 0px 10px inset black;
     border-radius: 0px;
     opacity: 0.9;
@@ -16521,13 +16521,12 @@ hr,
 .simple-calendar.classic .fsc-ya.fsc-qh:hover, .simple-calendar.classic .fsc-ya.fsc-qh.active, .simple-calendar.classic .fsc-ya.fsc-qh:focus {
 	color: #fff;
 	background-color: #de810d;
-	box-shadow: 0 0 8px #ff9f00 !important;	
 }
 
 .simple-calendar.classic .fsc-ya.fsc-ab {
 	padding: 3px 3px 3px 3px;
     line-height: normal;
-    border: 3px double #736953a6;
+    border: 1px solid #736953a6;
     box-shadow: 0px 0px 10px inset black;
     border-radius: 0px;
     opacity: 0.9;
@@ -16544,15 +16543,15 @@ hr,
 
 .simple-calendar.classic .fsc-ya.fsc-ab:hover, .simple-calendar.classic .fsc-ya.fsc-ab.active, .simple-calendar.classic .fsc-ya.fsc-ab:focus {
 	color: #fff;
-    background-color: #384582;
-	box-shadow: 0 0 8px #ff9f00 !important;	
+	background-color: #384582;
+	border-color: #736953a6;
 }
 
 .simple-calendar.classic .fsc-ya.fsc-kb {
-	border-radius: unset;
+    border-radius: unset;
     padding: 3px 3px 3px 3px;
     line-height: normal;
-    border: 3px double #736953a6;
+    border: 1px solid #736953a6;
     box-shadow: 0px 0px 10px inset black;
     border-radius: 0px;
     opacity: 0.9;
@@ -16563,24 +16562,21 @@ hr,
     border-image-width: 4px;
     border-image-outset: 0px;
     background-origin: padding-box;
-
 }
 
 .simple-calendar.classic .fsc-ya.fsc-kb:hover, .simple-calendar.classic .fsc-ya.fsc-kb.active, .simple-calendar.classic .fsc-ya.fsc-kb:focus {
     background-color: #2f581d;
     border-color: #564d3a;
     color: #fff;
-	box-shadow: 0 0 8px #ff9f00 !important;	
 }
 
  .simple-calendar.classic .fsc-ya.fsc-vh {
     background: #0a1829d9;
-	color: #d6d6d6;
-    border: 3px double #564d3a;
-	border-radius: unset;
+    color: #d6d6d6;
+    border-radius: unset;
     padding: 3px 3px 3px 3px;
     line-height: normal;
-    border: 3px double #736953a6;
+    border: 1px solid #736953a6;
     box-shadow: 0px 0px 10px inset black;
     border-radius: 0px;
     opacity: 0.9;
@@ -16595,19 +16591,16 @@ hr,
 
 .simple-calendar.classic .fsc-ya.fsc-vh:hover, .simple-calendar.classic .fsc-ya.fsc-vh.active, .simple-calendar.classic .fsc-ya.fsc-vh:focus {
 	background: #0a1829d9;
-	color: #d6d6d6;
-	box-shadow: 0 0 8px #ff9f00 !important;	
 }
 
 .simple-calendar.classic .fsc-ya.fsc-za {
     background-color: #922121;
     border-color: #922121;
     color: #fff;
-    border: 3px double #564d3a;
 	border-radius: unset;
     padding: 3px 3px 3px 3px;
     line-height: normal;
-    border: 3px double #736953a6;
+    border: 1px solid #736953a6;
     box-shadow: 0px 0px 10px inset black;
     border-radius: 0px;
     opacity: 0.9;
@@ -16623,7 +16616,6 @@ hr,
 .simple-calendar.classic .fsc-ya.fsc-za:hover, .simple-calendar.classic .fsc-ya.fsc-za.active, .simple-calendar.classic .fsc-ya.fsc-za:focus {
     background-color: #922121;
     color: #fff;
-	box-shadow: 0 0 8px #ff9f00 !important;	
 }
 
 .simple-calendar.classic .fsc-e .fsc-m .fsc-n .fsc-o {
@@ -16682,7 +16674,7 @@ hr,
     font-weight: var(--actor-input-font-weight);
     color: #d6d6d6;
     line-height: normal;
-    border: 3px double #564d3a;
+    border: 1px solid #564d3a;
     background: #0a1829d9;
 }
 
@@ -16692,7 +16684,7 @@ hr,
     font-weight: var(--actor-input-font-weight);
     color: #d6d6d6;
     line-height: normal;
-    border: 3px double #564d3a;
+    border: 1px solid #564d3a;
     background: #290a0ad9;
 }
 
@@ -16718,7 +16710,7 @@ hr,
 
 .simple-calendar.classic .fsc-e .fsc-m .fsc-n .fsc-o:hover {
     background-color: unset;
-	box-shadow: 0 0 8px #ff9f00 !important;	
+	box-shadow: 0 0 8px #ff9f00 !important;
 }
 
 .simple-calendar.classic.fsc-be .fsc-ng .fsc-ya {
@@ -16736,6 +16728,20 @@ hr,
     border-image-outset: 17px 14px 13px 14px !important;
     border-image-repeat: repeat repeat !important;
     border-image-source: url(../ui/players-border.webp) !important;
+}
+
+.simple-calendar.classic .fsc-jg .fsc-ya.fsc-qh:first-child, 
+.simple-calendar.classic .fsc-jg .fsc-ya.fsc-qh, 
+.simple-calendar.classic .fsc-jg .fsc-ya:first-child,
+.simple-calendar.classic .fsc-jg .fsc-ya.fsc-ab,
+.simple-calendar.classic .fsc-jg .fsc-ya.fsc-ab:first-child {
+    border-right-color: #736953a6;
+    border-left-color: #736953a6;
+}
+
+.simple-calendar.classic .fsc-e .fsc-m .fsc-n .fsc-o .fsc-v .fsc-z {
+    border-radius: 8px;
+    box-shadow: 1px 1px 5px;
 }
 
 .merchant-item {

--- a/css/wfrp4e.css
+++ b/css/wfrp4e.css
@@ -16470,7 +16470,273 @@ hr,
   text-shadow: 0px 0px 1px #00000063 !important; 
 }
 
+/* Simple Calendar Integration */
+.simple-calendar.classic .fsc-e {
+    background-color: #000000e8;
+    border-color: #736953a6 !important;
+    color: #efefef;
+}
 
+.simple-calendar.classic .fsc-e .fsc-g {
+    background-color: #000000e8;
+}
+
+.simple-calendar.classic .form-group {
+    background-color: #000000e8;
+    border-color: #736953a6;
+}
+
+.simple-calendar.classic .form-group:hover {
+    background-color: #000000e8;
+}
+
+.simple-calendar.classic .form-group label {
+	color: #ccc6c6;
+    font-family: CaslonAntique;
+    font-size: 24px;
+    font-weight: 500;
+    text-shadow: 1px 1px 5px #000000;
+}
+
+.simple-calendar.classic .form-group .notes {
+    color: #BBB;
+}
+
+.simple-calendar.classic .fsc-ya.fsc-qh {
+    padding: 3px 3px 3px 3px;
+    line-height: normal;
+    border: 3px double #736953a6;
+    box-shadow: 0px 0px 10px inset black;
+    border-radius: 0px;
+    opacity: 0.9;
+    text-align: center;
+    color: #e2e2e2;
+    text-shadow: 1px 1px 6px black;
+    border-image: url(../ui/footer-button.webp) 10 repeat;
+    border-image-width: 4px;
+    border-image-outset: 0px;
+    background-origin: padding-box;
+}
+
+.simple-calendar.classic .fsc-ya.fsc-qh:hover, .simple-calendar.classic .fsc-ya.fsc-qh.active, .simple-calendar.classic .fsc-ya.fsc-qh:focus {
+	color: #fff;
+	background-color: #de810d;
+	box-shadow: 0 0 8px #ff9f00 !important;	
+}
+
+.simple-calendar.classic .fsc-ya.fsc-ab {
+	padding: 3px 3px 3px 3px;
+    line-height: normal;
+    border: 3px double #736953a6;
+    box-shadow: 0px 0px 10px inset black;
+    border-radius: 0px;
+    opacity: 0.9;
+    text-align: center;
+    color: #fff;
+    text-shadow: 1px 1px 6px black;
+    border-image: url(../ui/footer-button.webp) 10 repeat;
+    border-image-width: 4px;
+    border-image-outset: 0px;
+    background-origin: padding-box;
+    background-color: #384582;
+    border-color: #384582;
+}
+
+.simple-calendar.classic .fsc-ya.fsc-ab:hover, .simple-calendar.classic .fsc-ya.fsc-ab.active, .simple-calendar.classic .fsc-ya.fsc-ab:focus {
+	color: #fff;
+    background-color: #384582;
+	box-shadow: 0 0 8px #ff9f00 !important;	
+}
+
+.simple-calendar.classic .fsc-ya.fsc-kb {
+	border-radius: unset;
+    padding: 3px 3px 3px 3px;
+    line-height: normal;
+    border: 3px double #736953a6;
+    box-shadow: 0px 0px 10px inset black;
+    border-radius: 0px;
+    opacity: 0.9;
+    text-align: center;
+    color: #fff;
+    text-shadow: 1px 1px 6px black;
+    border-image: url(../ui/footer-button.webp) 10 repeat;
+    border-image-width: 4px;
+    border-image-outset: 0px;
+    background-origin: padding-box;
+
+}
+
+.simple-calendar.classic .fsc-ya.fsc-kb:hover, .simple-calendar.classic .fsc-ya.fsc-kb.active, .simple-calendar.classic .fsc-ya.fsc-kb:focus {
+    background-color: #2f581d;
+    border-color: #564d3a;
+    color: #fff;
+	box-shadow: 0 0 8px #ff9f00 !important;	
+}
+
+ .simple-calendar.classic .fsc-ya.fsc-vh {
+    background: #0a1829d9;
+	color: #d6d6d6;
+    border: 3px double #564d3a;
+	border-radius: unset;
+    padding: 3px 3px 3px 3px;
+    line-height: normal;
+    border: 3px double #736953a6;
+    box-shadow: 0px 0px 10px inset black;
+    border-radius: 0px;
+    opacity: 0.9;
+    text-align: center;
+    color: #fff;
+    text-shadow: 1px 1px 6px black;
+    border-image: url(../ui/footer-button.webp) 10 repeat;
+    border-image-width: 4px;
+    border-image-outset: 0px;
+    background-origin: padding-box;
+}
+
+.simple-calendar.classic .fsc-ya.fsc-vh:hover, .simple-calendar.classic .fsc-ya.fsc-vh.active, .simple-calendar.classic .fsc-ya.fsc-vh:focus {
+	background: #0a1829d9;
+	color: #d6d6d6;
+	box-shadow: 0 0 8px #ff9f00 !important;	
+}
+
+.simple-calendar.classic .fsc-ya.fsc-za {
+    background-color: #922121;
+    border-color: #922121;
+    color: #fff;
+    border: 3px double #564d3a;
+	border-radius: unset;
+    padding: 3px 3px 3px 3px;
+    line-height: normal;
+    border: 3px double #736953a6;
+    box-shadow: 0px 0px 10px inset black;
+    border-radius: 0px;
+    opacity: 0.9;
+    text-align: center;
+    color: #fff;
+    text-shadow: 1px 1px 6px black;
+    border-image: url(../ui/footer-button.webp) 10 repeat;
+    border-image-width: 4px;
+    border-image-outset: 0px;
+    background-origin: padding-box;
+}
+
+.simple-calendar.classic .fsc-ya.fsc-za:hover, .simple-calendar.classic .fsc-ya.fsc-za.active, .simple-calendar.classic .fsc-ya.fsc-za:focus {
+    background-color: #922121;
+    color: #fff;
+	box-shadow: 0 0 8px #ff9f00 !important;	
+}
+
+.simple-calendar.classic .fsc-e .fsc-m .fsc-n .fsc-o {
+    border-color: #736953a6;
+}
+
+.simple-calendar.classic .fsc-xe {
+	color: #000000;
+    background-color: #fff;
+    background: url(../ui/frames/parchment-texture.webp) repeat;
+	border-image: url(../ui/frames/chat-message-border-private.webp) 21 repeat;
+    border-image-width: 10px;
+    border-image-outset: 8px;
+    border-radius: 0px;
+}
+
+.simple-calendar.classic .fsc-mf .tabs .fsc-nf.fsc-_h {
+    color: #ccc6c6;
+    font-family: CaslonAntique;
+    text-shadow: 1px 1px 5px #000000;
+    background: #310a0a91;
+}
+
+.simple-calendar.classic .fsc-mf .tabs .fsc-hb {
+    background: #352516;
+    color: #e2e2e2;
+    border: 1px solid #736953a6;
+    box-shadow: 0px 0px 10px inset black;
+    border-radius: 4px;
+    font-family: CaslonPro;
+    font-weight: 500;
+    font-size: var(--font-size-14);
+}
+
+.simple-calendar.classic .fsc-mf .tabs .fsc-nf .fsc-gb ul li.fsc-qf, .simple-calendar.classic .fsc-mf .tabs .fsc-nf .fsc-gb ul li:hover {
+    background: #352516;
+    color: #e2e2e2;
+    border: 1px solid #736953a6;
+	text-shadow: unset;
+}
+
+.simple-calendar.classic .fsc-mf .tabs .fsc-nf .fsc-gb ul li {
+    background: #352516;
+    color: #e2e2e2;
+    border: 1px solid #736953a6;
+	text-shadow: unset;
+}
+
+.simple-calendar.classic .fsc-mf .tabs .fsc-nf .fsc-gb ul li.fsc-jb {
+    color: #e2e2e2;
+}
+
+.simple-calendar.classic .fsc-mf .tabs .fsc-of {
+	font-family: var(--actor-input-font-family);
+    font-size: var(--actor-input-font-size);
+    font-weight: var(--actor-input-font-weight);
+    color: #d6d6d6;
+    line-height: normal;
+    border: 3px double #564d3a;
+    background: #0a1829d9;
+}
+
+.simple-calendar.classic .fsc-mf .tabs .fsc-of.fsc-qf, .simple-calendar.classic .fsc-mf .tabs .fsc-of.active, .simple-calendar.classic .fsc-mf .tabs .fsc-of:hover {
+	font-family: var(--actor-input-font-family);
+    font-size: var(--actor-input-font-size);
+    font-weight: var(--actor-input-font-weight);
+    color: #d6d6d6;
+    line-height: normal;
+    border: 3px double #564d3a;
+    background: #290a0ad9;
+}
+
+.simple-calendar .fsc-mf .tabs .fsc-pf {
+	border-bottom: 0;
+}
+
+.simple-calendar.classic .fsc-ra {
+    background-color: #000000e8;
+    border-color: #736953a6;
+    color: #efefef;
+}
+
+.simple-calendar.classic .fsc-e .fsc-m .fsc-n .fsc-o.fsc-t {
+    box-shadow: inset 0 0 5px #5c5cff;
+    background-color: #5c5cff;
+}
+
+.simple-calendar.classic .fsc-e .fsc-m .fsc-n .fsc-o.fsc-p {
+    box-shadow: inset 0 0 5px #40a94d;
+    background-color: #40a94d;
+}
+
+.simple-calendar.classic .fsc-e .fsc-m .fsc-n .fsc-o:hover {
+    background-color: unset;
+	box-shadow: 0 0 8px #ff9f00 !important;	
+}
+
+.simple-calendar.classic.fsc-be .fsc-ng .fsc-ya {
+    color: #FFF;
+}
+
+.simple-calendar.classic.fsc-be .fsc-ng .fsc-kb {
+    color: #296629;
+}
+
+.simple-calendar.window-app.fsc-be .window-content {
+    border: 2px solid #540e0ec2 !important;
+    border-image-slice: 24 20 19 17 !important;
+    border-image-width: 20px 20px 20px 20px !important;
+    border-image-outset: 17px 14px 13px 14px !important;
+    border-image-repeat: repeat repeat !important;
+    border-image-source: url(../ui/players-border.webp) !important;
+}
 
 .merchant-item {
   color: var(--actor-label-color);


### PR DESCRIPTION
Replaces simple calendar classic theme with the one that matches system style. Both full and compact views are updated.

For new setups Simple Calendar offers Dark theme by default, which works ok with the WFRP system but looks alien. Classic theme intended to mimic the DnD5e system style, so I chose to replace it to provide system look.

![Imgur](https://imgur.com/spTR2q2.png)
![Imgur](https://imgur.com/49wAvwB.png)
