### PR TITLE
Fix error when adding untrained skill

### DIFF
--- a/modules/actor/sheet/character-sheet.js
+++ b/modules/actor/sheet/character-sheet.js
@@ -216,7 +216,7 @@ export default class ActorSheetWfrp4eCharacter extends ActorSheetWfrp4e {
               {
                 label: game.i18n.localize("Yes"),
                 callback: dlg => {
-                  this.actor.createEmbeddedDocuments("Item", [skill.data]);
+                  this.actor.createEmbeddedDocuments("Item", [skill.toObject()]);
                 }
               },
               cancel:


### PR DESCRIPTION
When activating an untrained career skill on FVTT v10.283 and WFRP4e v6.1.1 the folllowing error occurs: 
![image](https://user-images.githubusercontent.com/521096/187909744-e6b8e5fd-1fa7-4487-82b4-640da48eb766.png)
