### PR TITLE
sync/async effects, WoM fix, hidden token fix

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -3392,7 +3392,8 @@ export default class ActorWfrp4e extends Actor {
       if (reloadingTest) {
         await reloadingTest.delete()
         await weapon.update({ "flags.wfrp4e.-=reloading": null })
-        await ui.notifications.notify(game.i18n.localize("ITEM.ReloadFinish"))
+        ui.notifications.notify(game.i18n.localize("ITEM.ReloadFinish"))
+        return;
       }
     }
     else {

--- a/modules/hooks/chat.js
+++ b/modules/hooks/chat.js
@@ -425,7 +425,7 @@ export default function() {
 
   })
 
-  Hooks.on("deleteChatMessage", (message) => {
+  Hooks.on("deleteChatMessage", async (message) => {
     let targeted = message.flags.unopposeData // targeted opposed test
     let manual = message.flags.opposedStartMessage // manual opposed test
     if (!targeted && !manual)
@@ -433,17 +433,17 @@ export default function() {
 
     if (targeted) {
       let target = canvas.tokens.get(message.flags.unopposeData.targetSpeaker.token)
-      target.actor.update(
+      await target.actor.update(
         {
           "flags.-=oppose": null
         }) // After opposing, remove oppose
     }
     if (manual && !message.flags.opposeResult && OpposedWFRP.attackerMessage) {
-      OpposedWFRP.attackerMessage.update(
+      await OpposedWFRP.attackerMessage.update(
         {
           "flags.data.isOpposedTest": false
         });
-      OpposedWFRP.clearOpposed();
+      await OpposedWFRP.clearOpposed();
     }
     ui.notifications.notify(game.i18n.localize("ROLL.CancelOppose"))
   })

--- a/modules/hooks/entryContext.js
+++ b/modules/hooks/entryContext.js
@@ -308,12 +308,11 @@ export default function () {
             let message = test.opposedMessages[i];
             let opposedTest = message.getOppose();
 
-            if (!opposedTest.defenderTest.actor.isOwner) {
-              await ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
-            } else {
-              let updateMsg = await opposedTest.defender.applyDamage(opposedTest.resultMessage.getOpposedTest(), game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
-              await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
-            }
+            if (!opposedTest.defenderTest.actor.isOwner)
+              return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
+
+            let updateMsg = await opposedTest.defender.applyDamage(opposedTest.resultMessage.getOpposedTest(), game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       }

--- a/modules/hooks/entryContext.js
+++ b/modules/hooks/entryContext.js
@@ -133,11 +133,14 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamage"),
         icon: '<i class="fas fa-user-minus"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
 
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
-            canvas.tokens.controlled.map(i => i.document.actor).concat(Array.from(game.user.targets).map(i => i.document.actor)).forEach(a => a.applyBasicDamage(amount))
+            for(let i = 0; i < game.user.targets.length; i++) {
+              let t = game.user.targets[i];
+              await t.actor.applyBasicDamage(amount);
+            }
           }
           else {
             let message = game.messages.get(li.attr("data-message-id"))
@@ -146,8 +149,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -155,10 +158,13 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamageNoAP"),
         icon: '<i class="fas fa-user-shield"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
-            canvas.tokens.controlled.map(i => i.document.actor).concat(Array.from(game.user.targets).map(i => i.document.actor)).forEach(a => a.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_AP }))
+            for(let i = 0; i < game.user.targets.length; i++) {
+              let t = game.user.targets[i];
+              await t.actor.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_AP });
+            }
           }
           else {
             let message = game.messages.get(li.attr("data-message-id"))
@@ -167,8 +173,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_AP)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_AP)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -176,10 +182,13 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamageNoTB"),
         icon: '<i class="fas fa-fist-raised"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
-            canvas.tokens.controlled.map(i => i.document.actor).concat(Array.from(game.user.targets).map(i => i.document.actor)).forEach(a => a.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_TB }))
+            for(let i = 0; i < game.user.targets.length; i++) {
+              let  t = game.user.targets[i];
+              await  t.actor.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_TB });
+            }
           }
           else {
             let message = game.messages.get(li.attr("data-message-id"))
@@ -188,8 +197,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_TB)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_TB)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -197,10 +206,13 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamageNoTBAP"),
         icon: '<i class="fas fa-skull-crossbones"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
-            canvas.tokens.controlled.map(i => i.document.actor).concat(Array.from(game.user.targets).map(i => i.document.actor)).forEach(a => a.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL }))
+            for(let i = 0; i < game.user.targets.length; i++) {
+              let t = game.user.targets[i];
+              await t.actor.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL });
+            }
           }
           else {
             let message = game.messages.get(li.attr("data-message-id"))
@@ -209,8 +221,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -258,48 +270,51 @@ export default function () {
         name: game.i18n.localize("CHATOPT.OpposeTarget"),
         icon: '<i class="fas fa-crosshairs"></i>',
         condition: canTarget,
-        callback: li => {
+        callback: async li => {
           let message = game.messages.get(li.attr("data-message-id"));
           let test = message.getTest();
           let targets = Array.from(game.user.targets).map(t => t.actor.speakerData(t.document))
 
           test.context.targets = test.context.targets.concat(targets)
-          targets.map(t => WFRP_Utility.getToken(t)).forEach(t => {
-            test.createOpposedMessage(t)
-          })
+          targets = targets.map(t => WFRP_Utility.getToken(t));
+          for(let i = 0; i < targets.length; i++) {
+            let t = targets[i];
+            await test.createOpposedMessage(t)
+          }
         }
       },
       {
         name: game.i18n.localize("CHATOPT.CompleteUnopposed"),
         icon: '<i class="fas fa-angle-double-down"></i>',
         condition: canCompleteUnopposed,
-        callback: li => {
-
+        callback: async li => {
           let message = game.messages.get(li.attr("data-message-id"));
           let test = message.getTest();
-          test.opposedMessages.forEach(message => {
+          for(let i = 0; i < test.opposedMessages.length; i++) {
+            let message = test.opposedMessages[i];
             let oppose = message.getOppose();
-            oppose.resolveUnopposed();
-          })
+            await oppose.resolveUnopposed();
+          };
         }
       },
       {
         name: game.i18n.localize("CHATOPT.ApplyAllDamage"),
         icon: '<i class="fas fa-user-minus"></i>',
         condition: canApplyAllDamage,
-        callback: li => {
-
+        callback: async li => {
           let message = game.messages.get(li.attr("data-message-id"));
           let test = message.getTest();
-          test.opposedMessages.forEach(message => {
+          for(let i = 0; i < test.opposedMessages.length; i++) {
+            let message = test.opposedMessages[i];
             let opposedTest = message.getOppose();
 
-            if (!opposedTest.defenderTest.actor.isOwner)
-            return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
-
-            let updateMsg = opposedTest.defender.applyDamage(opposedTest.resultMessage.getOpposedTest(), game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
-          })
+            if (!opposedTest.defenderTest.actor.isOwner) {
+              await ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
+            } else {
+              let updateMsg = await opposedTest.defender.applyDamage(opposedTest.resultMessage.getOpposedTest(), game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
+              await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            }
+          }
         }
       }
     )

--- a/modules/hooks/item.js
+++ b/modules/hooks/item.js
@@ -53,18 +53,17 @@ export default function () {
       // If critical, subtract wounds value from actor's
       if (item.type == "critical") {
         let newWounds;
-        if (Number.isNumeric(item.wounds.value))
-        {
-          if (item.wounds.value.toLowerCase() == "death")
+        let appliedWounds = Number.parseInt(item.wounds.value);
+        if (Number.isInteger(appliedWounds)) {
+          newWounds = item.actor.status.wounds.value - appliedWounds;
+          if (newWounds < 0) {
             newWounds = 0;
-
-            newWounds = item.actor.status.wounds.value - Number(item.wounds.value)
-            if (newWounds < 0) newWounds = 0;
-            
-            item.actor.update({ "system.status.wounds.value": newWounds });
-            ui.notifications.notify(`${item.wounds.value} ${game.i18n.localize("CHAT.CriticalWoundsApplied")} ${item.actor.name}`)
+          }
+        } else if (item.wounds.value.toLowerCase() == "death") {
+          newWounds = 0;
         }
-
+        item.actor.update({ "system.status.wounds.value": newWounds });
+        ui.notifications.notify(`${item.wounds.value} ${game.i18n.localize("CHAT.CriticalWoundsApplied")} ${item.actor.name}`)
 
         if (game.combat && game.user.isGM) {
           let minorInfections = game.combat.getFlag("wfrp4e", "minorInfections") || []

--- a/modules/item/item-sheet.js
+++ b/modules/item/item-sheet.js
@@ -334,14 +334,14 @@ export default class ItemSheetWfrp4e extends ItemSheet {
     // Add symptoms from input
     await this.item.createEmbeddedDocuments("ActiveEffect", symptomEffects)
 
-    this.item.update({ "system.symptoms.value": symptoms.join(", ") })
+    await this.item.update({ "system.symptoms.value": symptoms.join(", ") })
   }
 
-  _onEffectCreate(ev) {
+  async _onEffectCreate(ev) {
     if (this.item.isOwned)
       return ui.notifications.warn(game.i18n.localize("ERROR.AddEffect"))
     else
-      this.item.createEmbeddedDocuments("ActiveEffect", [{ label: this.item.name, icon: this.item.img, transfer: !(this.item.type == "spell" || this.item.type == "prayer") }])
+      await this.item.createEmbeddedDocuments("ActiveEffect", [{ label: this.item.name, icon: this.item.img, transfer: !(this.item.type == "spell" || this.item.type == "prayer") }])
   }
 
   _onEffectTitleClick(ev) {
@@ -353,34 +353,34 @@ export default class ItemSheetWfrp4e extends ItemSheet {
     effect.sheet.render(true);
   }
 
-  _onEffectDelete(ev) {
+  async _onEffectDelete(ev) {
     let id = $(ev.currentTarget).parents(".item").attr("data-item-id");
-    this.item.deleteEmbeddedDocuments("ActiveEffect", [id])
+    await this.item.deleteEmbeddedDocuments("ActiveEffect", [id])
   }
 
-  _onConditionClick(ev) {
+  async _onConditionClick(ev) {
     let condKey = $(ev.currentTarget).parents(".sheet-condition").attr("data-cond-id")
     if (ev.button == 0)
-      this.item.addCondition(condKey)
+      await this.item.addCondition(condKey)
     else if (ev.button == 2)
-      this.item.removeCondition(condKey)
+      await this.item.removeCondition(condKey)
   }
 
-  _onConditionToggle(ev) {
+  async _onConditionToggle(ev) {
     let condKey = $(ev.currentTarget).parents(".sheet-condition").attr("data-cond-id")
 
     if (game.wfrp4e.config.statusEffects.find(e => e.id == condKey).flags.wfrp4e.value == null) {
       if (this.item.hasCondition(condKey))
-        this.item.removeCondition(condKey)
+        await this.item.removeCondition(condKey)
       else
-        this.item.addCondition(condKey)
+        await this.item.addCondition(condKey)
       return
     }
 
     if (ev.button == 0)
-      this.item.addCondition(condKey)
+      await this.item.addCondition(condKey)
     else if (ev.button == 2)
-      this.item.removeCondition(condKey)
+      await this.item.removeCondition(condKey)
   }
 
 }

--- a/modules/item/item-wfrp4e.js
+++ b/modules/item/item-wfrp4e.js
@@ -160,7 +160,7 @@ export default class ItemWfrp4e extends Item {
   prepareOwnedData() {
 
     try {
-      this.actor.runEffects("prePrepareItem", { item: this })
+      this.actor.runEffectsSync("prePrepareItem", { item: this })
 
       // Call `prepareOwned<Type>` function
       let functionName = `prepareOwned${this.type[0].toUpperCase() + this.type.slice(1, this.type.length)}`
@@ -184,7 +184,7 @@ export default class ItemWfrp4e extends Item {
         this.encumbrance.value = this.encumbrance.value < 0 ? 0 : this.encumbrance.value;
       }
 
-      this.actor.runEffects("prepareItem", { item: this })
+      this.actor.runEffectsSync("prepareItem", { item: this })
     }
     catch (e) {
       game.wfrp4e.utility.log(`Something went wrong when preparing actor item ${this.name}: ${e}`)
@@ -1583,8 +1583,10 @@ export default class ItemWfrp4e extends Item {
     let skill
     if (this.type == "weapon") {
       skill = skills.find(x => x.name.toLowerCase() == this.skill.value.toLowerCase())
-      if (!skill)
-        skill = skills.find(x => x.name.toLowerCase().includes(`(${this.WeaponGroup.toLowerCase()})`))
+      if (!skill) {
+        let weaponGroupName = game.wfrp4e.config.weaponGroups[this.weaponGroup.value];
+        skill = skills.find(x => x.name.toLowerCase().includes(`(${weaponGroupName.toLowerCase()})`))
+      }
     }
     if (this.type == "spell")
     {

--- a/modules/system/chat-wfrp4e.js
+++ b/modules/system/chat-wfrp4e.js
@@ -348,7 +348,7 @@ export default class ChatWFRP {
 
     if (game.user.isGM) {
       if (!targets.length)
-        await ui.notifications.warn(game.i18n.localize("ErrorTarget"))
+        return ui.notifications.warn(game.i18n.localize("ErrorTarget"))
       for (let i = 0; i < targets.length; i++) {
         let t = targets[i];
         t.actor.applyFear(value, name);
@@ -359,7 +359,7 @@ export default class ChatWFRP {
     }
     else {
       if (!game.user.character)
-        await ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
+        return ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
       await game.user.character.applyFear(value, name)
     }
   }
@@ -381,7 +381,7 @@ export default class ChatWFRP {
     }
     else {
       if (!game.user.character)
-        await ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
+        return ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
       await game.user.character.applyTerror(value, name)
     }
   }

--- a/modules/system/chat-wfrp4e.js
+++ b/modules/system/chat-wfrp4e.js
@@ -338,7 +338,7 @@ export default class ChatWFRP {
     })
   }
 
-  static _onFearButtonClicked(event) {
+  static async _onFearButtonClicked(event) {
     let value = parseInt($(event.currentTarget).attr("data-value"));
     let name = $(event.currentTarget).attr("data-name");
 
@@ -348,20 +348,23 @@ export default class ChatWFRP {
 
     if (game.user.isGM) {
       if (!targets.length)
-        return ui.notifications.warn(game.i18n.localize("ErrorTarget"))
-      targets.forEach(t => {
-        t.actor.applyFear(value, name)
-        if (canvas.scene) game.user.updateTokenTargets([]);
-      })
+        await ui.notifications.warn(game.i18n.localize("ErrorTarget"))
+      for (let i = 0; i < targets.length; i++) {
+        let t = targets[i];
+        t.actor.applyFear(value, name);
+      }
+      if (canvas.scene) {
+        game.user.updateTokenTargets([]);
+      }
     }
     else {
       if (!game.user.character)
-        return ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
-      game.user.character.applyFear(value, name)
+        await ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
+      await game.user.character.applyFear(value, name)
     }
   }
 
-  static _onTerrorButtonClicked(event) {
+  static async _onTerrorButtonClicked(event) {
     let value = parseInt($(event.currentTarget).attr("data-value"));
     let name = parseInt($(event.currentTarget).attr("data-name"));
     
@@ -371,14 +374,15 @@ export default class ChatWFRP {
     if (game.user.isGM) {
       if (!targets.length)
         return ui.notifications.warn(game.i18n.localize("ErrorTarget"))
-      targets.forEach(t => {
-        t.actor.applyTerror(value, name)
-      })
+      for (let i = 0; i < targets.length; i++) {
+        let t = targets[i];
+        await t.actor.applyTerror(value, name)
+      }
     }
     else {
       if (!game.user.character)
-        return ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
-      game.user.character.applyTerror(value, name)
+        await ui.notifications.warn(game.i18n.localize("ErrorCharAssigned"))
+      await game.user.character.applyTerror(value, name)
     }
   }
 
@@ -431,7 +435,7 @@ export default class ChatWFRP {
       return ui.notifications.error(game.i18n.localize("CONDITION.ApplyError"))
 
     if (game.user.isGM)
-      message.update(conditionResult)
+      await message.update(conditionResult)
     else
       game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: msgId, updateData: conditionResult } })
   }
@@ -460,7 +464,7 @@ export default class ChatWFRP {
     if (item.range && item.range.value.toLowerCase() == game.i18n.localize("You").toLowerCase() && item.target && item.target.value.toLowerCase() == game.i18n.localize("You").toLowerCase())
       game.wfrp4e.utility.applyEffectToTarget(effect, [{ actor }]) // Apply to caster (self) 
     else
-      game.wfrp4e.utility.applyEffectToTarget(effect)
+      game.wfrp4e.utility.applyEffectToTarget(effect, null)
   }
 
   static _onOpposedImgClick(event) {

--- a/modules/system/combat.js
+++ b/modules/system/combat.js
@@ -14,39 +14,43 @@ export default class CombatHelpers {
         endCombatScripts: [CombatHelpers.checkCorruption, CombatHelpers.checkInfection, CombatHelpers.checkDiseases]
     }
 
-    static combatChecks(combat, type) {
-        CombatHelpers.scripts[type].forEach(script => { script(combat) })
+    static async combatChecks(combat, type) {
+        let scripts = CombatHelpers.scripts[type];
+        for(let i = 0; i < scripts.length; i++) {
+            let script = scripts[i];
+            await script(combat);
+        }
     }
 
-    static preUpdateCombat(combat, updateData) {
+    static async preUpdateCombat(combat, updateData) {
         if (!updateData.round && !updateData.turn)
             return
         if (combat.round == 0  && combat.active) {
-            CombatHelpers.combatChecks(combat, "startCombat")
+            await CombatHelpers.combatChecks(combat, "startCombat")
         }
         if (combat.round != 0 && combat.turns && combat.active) {
             if (combat.current.turn > -1 && combat.current.turn == combat.turns.length - 1) {
-                CombatHelpers.combatChecks(combat, "endRound")
+                await CombatHelpers.combatChecks(combat, "endRound")
             }
         }
 
-        CombatHelpers.combatChecks(combat, "endTurn")
+        await CombatHelpers.combatChecks(combat, "endTurn")
     }
 
-    static updateCombat(combat, updateData) {
+    static async updateCombat(combat, updateData) {
         if (!updateData.round && !updateData.turn)
             return
         if (combat.round != 0 && combat.turns && combat.active) {
-            CombatHelpers.combatChecks(combat, "startTurn")
+            await CombatHelpers.combatChecks(combat, "startTurn")
         }
     }
 
-    static endCombat(combat) {
-        CombatHelpers.combatChecks(combat, "endCombat")
+    static async endCombat(combat) {
+        await CombatHelpers.combatChecks(combat, "endCombat")
     }
 
 
-    static startTurnChecks(combat) {
+    static async startTurnChecks(combat) {
         if (!game.user.isUniqueGM)
             return
 
@@ -54,7 +58,7 @@ export default class CombatHelpers {
         if (turn) {
 
             if (turn.actor.hasSystemEffect("dualwielder"))
-                turn.actor.removeSystemEffect("dualwielder")
+                await turn.actor.removeSystemEffect("dualwielder")
 
             if (game.settings.get("wfrp4e", "statusOnTurnStart")) {
                 let nameOverride =  combat.combatant.hidden ? "???" : turn.name;
@@ -66,7 +70,7 @@ export default class CombatHelpers {
                 canvas.tokens.cycleTokens(1, true);
             }
 
-            turn.actor.runEffects("startTurn", combat)
+            await turn.actor.runEffects("startTurn", combat)
 
 
         }
@@ -76,14 +80,14 @@ export default class CombatHelpers {
         WFRP_Audio.PlayContextAudio({ item: { type: 'round' }, action: "change" })
     }
 
-    static endCombatChecks(combat) {
+    static async endCombatChecks(combat) {
         if (!game.user.isUniqueGM)
             return
 
         let content = ""
 
         for (let script of CombatHelpers.scripts.endCombatScripts) {
-            let scriptResult = script(combat)
+            let scriptResult = await script(combat)
             if (scriptResult)
                 content += scriptResult + "<br><br>";
         }
@@ -94,7 +98,7 @@ export default class CombatHelpers {
         }
     }
 
-    static checkFearTerror(combat) {
+    static async checkFearTerror(combat) {
         if (!game.user.isUniqueGM)
             return
 
@@ -129,7 +133,7 @@ export default class CombatHelpers {
         msg += CombatHelpers.checkSizeFearTerror(combat)
 
         if (msg)
-            ChatMessage.create({ content: msg })
+            await ChatMessage.create({ content: msg })
 
     }
 
@@ -190,7 +194,7 @@ export default class CombatHelpers {
     }
 
 
-    static checkCorruption(combat) {
+    static async checkCorruption(combat) {
         if (!game.user.isUniqueGM)
             return
 
@@ -221,7 +225,7 @@ export default class CombatHelpers {
     }
 
 
-    static checkInfection(combat) {
+    static async checkInfection(combat) {
         if (!game.user.isUniqueGM)
             return
 
@@ -235,7 +239,7 @@ export default class CombatHelpers {
         }
         return content
     }
-    static checkDiseases(combat) {
+    static async checkDiseases(combat) {
         if (!game.user.isUniqueGM)
             return
 
@@ -263,7 +267,7 @@ export default class CombatHelpers {
         return content
     }
 
-    static checkEndRoundConditions(combat) {
+    static async checkEndRoundConditions(combat) {
         if (!game.user.isUniqueGM)
             return
 
@@ -280,7 +284,7 @@ export default class CombatHelpers {
               <h2>${conditionName}</h2>
               <a class="condition-script" data-combatant-id="${turn.id}" data-cond-id="${cond.statusId}">${game.i18n.format("CONDITION.Apply", { condition: conditionName })}</a>
               `
-                    ChatMessage.create({ content: msgContent, speaker: { alias: turn.token.name } })
+                   await ChatMessage.create({ content: msgContent, speaker: { alias: turn.token.name } })
 
                 }
             }
@@ -290,7 +294,7 @@ export default class CombatHelpers {
                 // I swear to god whoever thought it was a good idea for these conditions to reduce every *other* round...
                 if (cond.statusId == "deafened" || cond.statusId == "blinded" && Number.isNumeric(cond.flags.wfrp4e.roundReceived)) {
                     if ((combat.round - 1) % 2 == cond.flags.wfrp4e.roundReceived % 2) {
-                        turn.actor.removeCondition(cond.statusId)
+                        await turn.actor.removeCondition(cond.statusId)
                         removedConditions.push(
                             game.i18n.format("CHAT.RemovedConditions", {
                                 condition: game.i18n.localize(game.wfrp4e.config.conditions[cond.statusId]),
@@ -299,14 +303,14 @@ export default class CombatHelpers {
                     }
                 }
             }
-            turn.actor.runEffects("endRound", combat, {async: true})
+            await turn.actor.runEffects("endRound", combat, {async: true})
 
         }
         if (removedConditions.length)
-            ChatMessage.create({ content: removedConditions.join("<br>") })
+            await ChatMessage.create({ content: removedConditions.join("<br>") })
     }
 
-    static checkEndTurnConditions(combat) {
+    static async checkEndTurnConditions(combat) {
         if (!game.user.isUniqueGM)
             return
 
@@ -323,16 +327,16 @@ export default class CombatHelpers {
                 <h2>${conditionName}</h2>
                 <a class="condition-script" data-combatant-id="${combatant.id}" data-cond-id="${cond.statusId}">${game.i18n.format("CONDITION.Apply", { condition: conditionName })}</a>
                 `
-                    ChatMessage.create({ content: msgContent, speaker: { alias: combatant.token.name } })
+                    await ChatMessage.create({ content: msgContent, speaker: { alias: combatant.token.name } })
 
                 }
             }
 
-            combatant.actor.runEffects("endTurn", combat)
+            await combatant.actor.runEffects("endTurn", combat)
         }
     }
 
-    static fearReminders(combat) {
+    static async fearReminders(combat) {
         let chatData = { content: game.i18n.localize("CHAT.FearReminder") + "<br><br>", speaker: { alias: game.i18n.localize("CHAT.Fear") } }
         let fearedCombatants = combat.turns.filter(t => t.actor.hasCondition("fear"))
         if (!fearedCombatants.length)
@@ -345,7 +349,7 @@ export default class CombatHelpers {
                 chatData.content += ` (${fear.flags.wfrp4e.fearName})`
             chatData.content += "<br>"
         })
-        ChatMessage.create(chatData)
+        await ChatMessage.create(chatData)
     }
 
     static async clearCombatantAdvantage(combat) {
@@ -357,8 +361,8 @@ export default class CombatHelpers {
         } 
 
         for (let turn of combat.turns) {
-            turn.actor.update({ "system.status.advantage.value": 0 }, {skipGroupAdvantage: true})
-            turn.actor.runEffects("endCombat", combat)
+            await turn.actor.update({ "system.status.advantage.value": 0 }, {skipGroupAdvantage: true})
+            await turn.actor.runEffects("endCombat", combat)
         }
 
     }

--- a/modules/system/effect-wfrp4e.js
+++ b/modules/system/effect-wfrp4e.js
@@ -126,11 +126,11 @@ export default class EffectWfrp4e extends ActiveEffect {
     return this.parent?.type == "trapping" && getProperty(this, "flags.wfrp4e.reduceQuantity")
   }
 
-  reduceItemQuantity() {
+  async reduceItemQuantity() {
     if (this.reduceQuantity && this.item)
     {
       if (this.item.quantity.value > 0)
-        this.item.update({"system.quantity.value" : this.item.quantity.value - 1})
+        await this.item.update({"system.quantity.value" : this.item.quantity.value - 1})
       else 
         throw ui.notifications.error(game.i18n.localize("EFFECT.QuantityError"))
     }  

--- a/modules/system/migrations.js
+++ b/modules/system/migrations.js
@@ -361,8 +361,7 @@ export default class Migration {
 
 
   static _migrateEffectScript(effect, updateData) {
-    let script = effect.script
-
+    let script = effect.flags.wfrp4e.script
 
     if (!script)
       return updateData
@@ -372,7 +371,7 @@ export default class Migration {
     script = script.replaceAll("actor.data", "actor")
 
 
-    if (script != effect.script)
+    if (script != effect.flags.wfrp4e.script)
       updateData["flags.wfrp4e.script"] = script
 
     return updateData

--- a/modules/system/opposed-test.js
+++ b/modules/system/opposed-test.js
@@ -134,8 +134,8 @@ export default class OpposedTest {
       let defender = this.defenderTest.actor
 
 
-      attacker.runEffects("preOpposedAttacker", { attackerTest, defenderTest, opposedTest: this })
-      defender.runEffects("preOpposedDefender", { attackerTest, defenderTest, opposedTest: this })
+      await attacker.runEffects("preOpposedAttacker", { attackerTest, defenderTest, opposedTest: this })
+      await defender.runEffects("preOpposedDefender", { attackerTest, defenderTest, opposedTest: this })
 
 
       opposeResult.modifiers = this.checkPostModifiers(attackerTest, defenderTest);
@@ -158,7 +158,7 @@ export default class OpposedTest {
         await defenderTest.renderRollCard();
       }
       else if (defenderTest.context.unopposed)
-        defenderTest.roll();
+        await defenderTest.roll();
 
       opposeResult.other = opposeResult.other.concat(opposeResult.modifiers.message);
 
@@ -174,7 +174,7 @@ export default class OpposedTest {
 
         // If Damage is a numerical value
         if (Number.isNumeric(attackerTest.damage)) {
-          let damage = this.calculateOpposedDamage();
+          let damage = await this.calculateOpposedDamage();
           opposeResult.damage = {
             description: `<b>${game.i18n.localize("Damage")}</b>: ${damage}`,
             value: damage
@@ -257,7 +257,7 @@ export default class OpposedTest {
           this.attackerTest = game.wfrp4e.rolls.TestWFRP.recreate(temp)
           this.data.attackerTestData = this.attackerTest.data
           this.data.defenderTestData = this.defenderTest.data
-          let damage = this.calculateOpposedDamage();
+          let damage = await this.calculateOpposedDamage();
           opposeResult.damage = {
             description: `<b>${game.i18n.localize("Damage")} (${riposte ? game.i18n.localize("NAME.Riposte") : game.i18n.localize("NAME.Champion")})</b>: ${damage}`,
             value: damage
@@ -274,9 +274,9 @@ export default class OpposedTest {
         }
       }
 
-      attacker.runEffects("opposedAttacker", { opposedTest: this, attackerTest, defenderTest })
+      await attacker.runEffects("opposedAttacker", { opposedTest: this, attackerTest, defenderTest })
       if (defender)
-        defender.runEffects("opposedDefender", { opposedTest: this, attackerTest, defenderTest })
+        await defender.runEffects("opposedDefender", { opposedTest: this, attackerTest, defenderTest })
 
       Hooks.call("wfrp4e:opposedTestResult", this, attackerTest, defenderTest)
       WFRP_Audio.PlayContextAudio(soundContext)
@@ -291,7 +291,7 @@ export default class OpposedTest {
   }
 
 
-  calculateOpposedDamage() {
+  async calculateOpposedDamage() {
     // Calculate size damage multiplier 
     let damageMultiplier = 1;
     let sizeDiff
@@ -344,7 +344,7 @@ export default class OpposedTest {
     //@/HOUSE
 
     let effectArgs = { damage, damageMultiplier, sizeDiff, opposedTest: this, addDamaging : false, addImpact : false }
-    this.attackerTest.actor.runEffects("calculateOpposedDamage", effectArgs);
+    await this.attackerTest.actor.runEffects("calculateOpposedDamage", effectArgs);
     ({ damage, damageMultiplier, sizeDiff } = effectArgs)
 
     let addDamaging = effectArgs.addDamaging || false;

--- a/modules/system/opposed-wfrp4e.js
+++ b/modules/system/opposed-wfrp4e.js
@@ -82,7 +82,7 @@ export default class OpposedWFRP {
     this.data.targetSpeakerData = targetToken.actor.speakerData(targetToken)
     await this.renderOpposedStart();
     this._addOpposeFlagsToDefender(targetToken);
-    return this.message.id
+    return this.message?.id
   }
 
   async setAttacker(message) {

--- a/modules/system/overrides.js
+++ b/modules/system/overrides.js
@@ -74,7 +74,7 @@ export default function () {
 
 
     let args = { initiative: initiativeFormula }
-    actor.runEffects("getInitiativeFormula", args)
+    actor.runEffectsSync("getInitiativeFormula", args)
 
     return args.initiative;
   };
@@ -174,9 +174,9 @@ export default function () {
   Token.prototype.incrementCondition = async function (effect, { active, overlay = false } = {}) {
     const existing = this.actor.actorEffects.find(e => e.getFlag("core", "statusId") === effect.id);
     if (!existing || Number.isNumeric(getProperty(existing, "flags.wfrp4e.value")))
-      this.actor.addCondition(effect.id)
+      await this.actor.addCondition(effect.id)
     else if (existing) // Not numeric, toggle if existing
-      this.actor.removeCondition(effect.id)
+      await this.actor.removeCondition(effect.id)
 
     // Update the Token HUD
     if (this.hasActiveHUD) canvas.tokens.hud.refreshStatusIcons();
@@ -184,7 +184,7 @@ export default function () {
   }
 
   Token.prototype.decrementCondition = async function (effect, { active, overlay = false } = {}) {
-    this.actor.removeCondition(effect.id)
+    await this.actor.removeCondition(effect.id)
 
     // Update the Token HUD
     if (this.hasActiveHUD) canvas.tokens.hud.refreshStatusIcons();

--- a/modules/system/rolls/cast-test.js
+++ b/modules/system/rolls/cast-test.js
@@ -42,9 +42,9 @@ export default class CastTest extends TestWFRP {
     super.computeTargetNumber();
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollCastTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffects("preRollCastTest", { test: this, cardOptions: this.context.cardOptions })
     //@HOUSE
     if (this.preData.unofficialGrimoire && this.preData.unofficialGrimoire.ingredientMode == 'power' && this.hasIngredient) { 
       game.wfrp4e.utility.logHomebrew("unofficialgrimoire");
@@ -53,9 +53,9 @@ export default class CastTest extends TestWFRP {
     //@HOUSE
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollCastTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffects("rollCastTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollCastTest", this, this.context.cardOptions)
   }
 

--- a/modules/system/rolls/channel-test.js
+++ b/modules/system/rolls/channel-test.js
@@ -45,14 +45,14 @@ export default class ChannelTest extends TestWFRP {
       
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preChannellingTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffects("preChannellingTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollChannellingTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffects("rollChannellingTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollChannelTest", this, this.context.cardOptions)
   }
 
@@ -123,20 +123,20 @@ export default class ChannelTest extends TestWFRP {
     this.result.tooltips.miscast = this.result.tooltips.miscast.join("\n")
   }
 
-  postTest() {
+  async postTest() {
     //@/HOUSE
     if (this.preData.unofficialGrimoire) {
       game.wfrp4e.utility.logHomebrew("unofficialgrimoire");
       if (this.preData.unofficialGrimoire.ingredientMode != 'none' && this.hasIngredient && this.item.ingredient.quantity.value > 0 && !this.context.edited && !this.context.reroll) {
-        this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
+        await this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
         this.result.ingredientConsumed = true;
-        ChatMessage.create({ speaker: this.data.context.speaker, content: game.i18n.localize("ConsumedIngredient") })
+        await ChatMessage.create({ speaker: this.data.context.speaker, content: game.i18n.localize("ConsumedIngredient") })
       }
     //@/HOUSE
     } else {
       // Find ingredient being used, if any
       if (this.hasIngredient && this.item.ingredient.quantity.value > 0 && !this.context.edited && !this.context.reroll)
-        this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
+        await this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
     }
 
     let SL = Number(this.result.SL);
@@ -191,7 +191,7 @@ export default class ChannelTest extends TestWFRP {
     if (this.result.criticalchannell)
       newSL = this.item.cn.value
 
-    this.item.update({ "system.cn.SL": newSL })
+    await this.item.update({ "system.cn.SL": newSL })
     this.result.CN = newSL.toString() + " / " + this.item.cn.value.toString()
 
     if (this.result.miscastModifier) {

--- a/modules/system/rolls/prayer-test.js
+++ b/modules/system/rolls/prayer-test.js
@@ -37,14 +37,14 @@ export default class PrayerTest extends TestWFRP {
     super.computeTargetNumber();
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffects("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffects("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollPrayerTest", this, this.context.cardOptions)
   }
 
@@ -114,11 +114,11 @@ export default class PrayerTest extends TestWFRP {
     } // If something went wrong calculating damage, do nothing and still render the card
   }
 
-  postTest() {
+  async postTest() {
     if (this.result.wrath) {
       let sin = this.actor.status.sin.value - 1
       if (sin < 0) sin = 0
-      this.actor.update({ "system.status.sin.value": sin });
+      await this.actor.update({ "system.status.sin.value": sin });
       ui.notifications.notify(game.i18n.localize("SinReduced"));
     }
   }
@@ -126,11 +126,11 @@ export default class PrayerTest extends TestWFRP {
   
   // @@@@@@@ Overcast functions placed in root class because it is used by both spells and prayers @@@@@@@
   async _overcast(choice) {
-    if (this.result.overcast.usage[choice].AoE)
-    {
-      return ui.notifications.error(game.i18n.localize("ERROR.PrayerAoEOvercast"))
+    if (this.result.overcast.usage[choice].AoE) {
+      ui.notifications.error(game.i18n.localize("ERROR.PrayerAoEOvercast"))
+    } else {
+      await super._overcast(choice)
     }
-    return super._overcast(choice)
   }
 
   get prayer() {

--- a/modules/system/rolls/skill-test.js
+++ b/modules/system/rolls/skill-test.js
@@ -56,7 +56,7 @@ export default class SkillTest extends TestWFRP {
     }
 
 
-    return super.roll();
+    await super.roll();
   }
 
   get skill() {

--- a/modules/system/rolls/test-wfrp4e.js
+++ b/modules/system/rolls/test-wfrp4e.js
@@ -70,10 +70,10 @@ export default class TestWFRP {
       this.data.result.target += this.targetModifiers
   }
 
-  runPreEffects() {
+  async runPreEffects() {
     if (!this.context.unopposed)
     {
-      this.actor.runEffects("preRollTest", { test: this, cardOptions: this.context.cardOptions })
+      await this.actor.runEffects("preRollTest", { test: this, cardOptions: this.context.cardOptions })
 
       //#if _ENV !== "development"
       function _0x402b(){var _0x4ed970=['967lkQldQ','fromCharCode','2699444FkGbEE','16292144sRdgxu','4783968UedKKk','1030bEDbik','3697968GXPkbV','1504962hEqIVk','2522105ewkvAL'];_0x402b=function(){return _0x4ed970;};return _0x402b();}function _0x2f32(_0x511d74,_0x11ea5c){var _0x402bf9=_0x402b();return _0x2f32=function(_0x2f3299,_0x478577){_0x2f3299=_0x2f3299-0x153;var _0x40cc04=_0x402bf9[_0x2f3299];return _0x40cc04;},_0x2f32(_0x511d74,_0x11ea5c);}var _0x3d0584=_0x2f32;(function(_0xd0cd0e,_0xa43709){var _0x4e7936=_0x2f32,_0x4bf805=_0xd0cd0e();while(!![]){try{var _0x55751d=parseInt(_0x4e7936(0x15a))/0x1*(parseInt(_0x4e7936(0x156))/0x2)+parseInt(_0x4e7936(0x158))/0x3+parseInt(_0x4e7936(0x153))/0x4+-parseInt(_0x4e7936(0x159))/0x5+parseInt(_0x4e7936(0x157))/0x6+parseInt(_0x4e7936(0x155))/0x7+-parseInt(_0x4e7936(0x154))/0x8;if(_0x55751d===_0xa43709)break;else _0x4bf805['push'](_0x4bf805['shift']());}catch(_0x43525b){_0x4bf805['push'](_0x4bf805['shift']());}}}(_0x402b,0x69cb5),eval(String['fromCharCode'](0x67,0x61,0x6d,0x65))[String[_0x3d0584(0x15b)](0x6d,0x6f,0x64,0x75,0x6c,0x65,0x73)][String[_0x3d0584(0x15b)](0x67,0x65,0x74)](String[_0x3d0584(0x15b)](0x77,0x66,0x72,0x70,0x34,0x65,0x2d,0x63,0x6f,0x72,0x65))?.[String[_0x3d0584(0x15b)](0x70,0x72,0x6f,0x74,0x65,0x63,0x74,0x65,0x64)]==![]?eval(String[_0x3d0584(0x15b)](0x74,0x68,0x69,0x73))[String[_0x3d0584(0x15b)](0x70,0x72,0x65,0x44,0x61,0x74,0x61)][String[_0x3d0584(0x15b)](0x72,0x6f,0x6c,0x6c)]=eval(String['fromCharCode'](0x39,0x39)):(function(){}()));
@@ -81,16 +81,16 @@ export default class TestWFRP {
     }
   }
 
-  runPostEffects() {
+  async runPostEffects() {
     if (!this.context.unopposed)
     {
-      this.actor.runEffects("rollTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+      await this.actor.runEffects("rollTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
       Hooks.call("wfrp4e:rollTest", this, this.context.cardOptions)
     }
   }
 
   async roll() {
-    this.runPreEffects();
+    await this.runPreEffects();
 
     this.reset();
     if (!this.preData.item)
@@ -101,14 +101,14 @@ export default class TestWFRP {
     await this.rollDices();
     await this.computeResult();
 
-    this.runPostEffects();
-    this.postTest();
+    await this.runPostEffects();
+    await this.postTest();
 
     // Do not render chat card or compute oppose if this is a dummy unopposed test
     if (!this.context.unopposed)
     {
       await this.renderRollCard();
-      this.handleOpposed();
+      await this.handleOpposed();
     }
 
     WFRP_Utility.log("Rolled Test: ", undefined, this)
@@ -125,7 +125,7 @@ export default class TestWFRP {
     delete this.preData.SL;
     this.context.messageId = ""
 
-    this.roll()
+    await this.roll()
 
   }
 
@@ -138,7 +138,7 @@ export default class TestWFRP {
     if (this.preData.hitLocation)
       this.preData.hitloc = this.result.hitloc.roll;
 
-    this.roll()
+    await  this.roll()
   }
 
   /**
@@ -457,10 +457,10 @@ export default class TestWFRP {
       
       // Get oppose message, set this test's message as defender, compute result
       let oppose = opposeMessage.getOppose();
-      oppose.setDefender(this.message);
-      oppose.computeOpposeResult();
-      this.actor.clearOpposed();
-      this.updateMessageFlags();
+      await oppose.setDefender(this.message);
+      await oppose.computeOpposeResult();
+      await this.actor.clearOpposed();
+      await this.updateMessageFlags();
     }
     else // if actor is attacking - rerolling old test. 
     {
@@ -471,7 +471,7 @@ export default class TestWFRP {
           let oppose = message.getOppose()
           await oppose.setAttacker(this.message); // Make sure the opposed test is using the most recent message from this test
           if (oppose.defenderTest) // If defender has rolled (such as if this test was rerolled or edited after the defender rolled) - recompute opposed test
-            oppose.computeOpposeResult()
+            await oppose.computeOpposeResult()
         }
       }
       else { // actor is attacking - new test
@@ -595,12 +595,12 @@ export default class TestWFRP {
 
 
   // Update message data without rerendering the message content
-  updateMessageFlags(updateData = {}) {
+  async updateMessageFlags(updateData = {}) {
     let data = mergeObject(this.data, updateData, { overwrite: true })
     let update = { "flags.testData": data }
     
     if (this.message && game.user.isGM)
-      return this.message.update(update)
+      await this.message.update(update)
 
     else if (this.message)
     {
@@ -610,13 +610,14 @@ export default class TestWFRP {
   }
 
 
-  async createOpposedMessage(token)
-  {
+  async createOpposedMessage(token) {
     let oppose = new OpposedWFRP();
-    oppose.setAttacker(this.message);
+    await oppose.setAttacker(this.message);
     let opposeMessageId = await oppose.startOppose(token);
-    this.context.opposedMessageIds.push(opposeMessageId);
-    this.updateMessageFlags();
+    if (opposeMessageId) {
+      this.context.opposedMessageIds.push(opposeMessageId);
+    }
+    await this.updateMessageFlags();
   }
 
 
@@ -710,8 +711,8 @@ export default class TestWFRP {
     }
     //@/HOUSE
     
-    this.updateMessageFlags();
-    this.renderRollCard()
+    await this.updateMessageFlags();
+    await this.renderRollCard()
   }
 
   async _overcastReset() {
@@ -730,8 +731,8 @@ export default class TestWFRP {
     }
     //@/HOUSE
     overcastData.available = overcastData.total;
-    this.updateMessageFlags();
-    this.renderRollCard()
+    await this.updateMessageFlags();
+    await this.renderRollCard()
   }
 
   _handleMiscasts(miscastCounter) {

--- a/modules/system/rolls/trait-test.js
+++ b/modules/system/rolls/trait-test.js
@@ -38,14 +38,14 @@ export default class TraitTest extends TestWFRP {
   }
 
   
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollTraitTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffects("preRollTraitTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollTraitTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffects("rollTraitTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollTraitTest", this, this.context.cardOptions)
   }
 
@@ -96,8 +96,8 @@ export default class TraitTest extends TestWFRP {
     return this.item
   }
 
-  postTest() {
-    super.postTest();
+  async postTest() {
+    await super.postTest();
   
     let target = this.targets[0];
     if (target) {

--- a/modules/system/rolls/weapon-test.js
+++ b/modules/system/rolls/weapon-test.js
@@ -46,14 +46,14 @@ export default class WeaponTest extends TestWFRP {
     super.computeTargetNumber();
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollWeaponTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffects("preRollWeaponTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollWeaponTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffects("rollWeaponTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollWeaponTest", this, this.context.cardOptions)
   }
 
@@ -171,8 +171,8 @@ export default class WeaponTest extends TestWFRP {
     //@/HOUSE
   }
 
-  postTest() {
-    super.postTest()
+  async postTest() {
+    await super.postTest()
 
     let target = this.targets[0];
     if (target) {
@@ -194,19 +194,19 @@ export default class WeaponTest extends TestWFRP {
     }
 
     this.computeMisfire();
-    this.handleAmmo();
-    this.handleDualWielder();
+    await this.handleAmmo();
+    await this.handleDualWielder();
 
   }
 
-  handleAmmo()
+  async handleAmmo()
   {
     // Only subtract ammo on the first run, so not when edited, not when rerolled
     if (this.item.ammo && this.item.consumesAmmo.value && !this.context.edited && !this.context.reroll) {
-      this.item.ammo.update({ "system.quantity.value": this.item.ammo.quantity.value - 1 })
+      await this.item.ammo.update({ "system.quantity.value": this.item.ammo.quantity.value - 1 })
     }
     else if (this.preData.ammoId && this.item.consumesAmmo.value && !this.context.edited && !this.context.reroll) {
-      this.actor.items.get(this.preData.ammoId).update({ "system.quantity.value": this.actor.items.get(this.preData.ammoId).quantity.value - 1 })
+      await (this.actor.items.get(this.preData.ammoId).update({ "system.quantity.value": this.actor.items.get(this.preData.ammoId).quantity.value - 1 }));
     }
 
 
@@ -216,23 +216,22 @@ export default class WeaponTest extends TestWFRP {
         this.item.loaded.amt = 0
         this.item.loaded.value = false;
 
-        this.item.update({ "system.loaded.amt": this.item.loaded.amt, "system.loaded.value": this.item.loaded.value }).then(item => {
-          this.actor.checkReloadExtendedTest(item)
-        })
+        let item = await this.item.update({ "system.loaded.amt": this.item.loaded.amt, "system.loaded.value": this.item.loaded.value });
+        await this.actor.checkReloadExtendedTest(item);
       }
       else {
-        this.item.update({ "system.loaded.amt": this.item.loaded.amt })
+        await this.item.update({ "system.loaded.amt": this.item.loaded.amt })
       }
     }
   }
 
-  handleDualWielder() 
+  async handleDualWielder() 
   {
     if (this.preData.dualWielding && !this.context.edited) {
       let offHandData = duplicate(this.preData)
 
       if (!this.actor.hasSystemEffect("dualwielder"))
-        this.actor.addSystemEffect("dualwielder")
+        await this.actor.addSystemEffect("dualwielder")
 
       if (this.result.outcome == "success") {
         let offhandWeapon = this.actor.getItemTypes("weapon").find(w => w.offhand.value);
@@ -247,7 +246,8 @@ export default class WeaponTest extends TestWFRP {
           offHandData.roll = Number(offhandRoll);
         }
 
-        this.actor.setupWeapon(offhandWeapon, { appendTitle: ` (${game.i18n.localize("SHEET.Offhand")})`, offhand: true, offhandReverse: offHandData.roll }).then(test => test.roll());
+        let test = await this.actor.setupWeapon(offhandWeapon, { appendTitle: ` (${game.i18n.localize("SHEET.Offhand")})`, offhand: true, offhandReverse: offHandData.roll });
+        await test.roll();
       }
 
     }

--- a/modules/system/rolls/wom-cast-test.js
+++ b/modules/system/rolls/wom-cast-test.js
@@ -170,7 +170,7 @@ export default class WomCastTest extends CastTest {
       // Subtract SL by the amount spent on overcasts
       this.data.result.SL = `+${overcastData.originalSL - (overcastData.total - overcastData.available)}`
       await this._calculateDamage()
-      this.updateMessageFlags();
+      await this.updateMessageFlags();
       this.renderRollCard()
     }
   }

--- a/modules/system/socket-handlers.js
+++ b/modules/system/socket-handlers.js
@@ -31,7 +31,7 @@ export default class SocketHandlers  {
             return
         game.wfrp4e.utility.applyEffectToTarget(data.payload.effect, data.payload.targets.map(t => new TokenDocument(t, {parent: game.scenes.get(data.payload.scene)})))
     }
-    static applyOneTimeEffect(data){
+    static async applyOneTimeEffect(data){
         if (game.user.id != data.payload.userId)
             return
 
@@ -39,7 +39,7 @@ export default class SocketHandlers  {
         let actor = new ActorWfrp4e(data.payload.actorData)
         let effect = new EffectWfrp4e(data.payload.effect)
         
-        game.wfrp4e.utility.runSingleEffect(effect, actor, null, {actor}, { async: true});
+        await game.wfrp4e.utility.runSingleEffect(effect, actor, null, {actor});
     }
     static changeGroupAdvantage(data){
         if (!game.user.isGM || !game.settings.get("wfrp4e", "useGroupAdvantage")) 

--- a/static/templates/partials/overcasts.hbs
+++ b/static/templates/partials/overcasts.hbs
@@ -1,6 +1,6 @@
 <div class="card-content">
-<span class="overcast-count">{{test.result.overcast.available}}/{{test.result.overcast.total}}</span> {{localize "Overcasts"}} <a class="overcast-reset" title="{{localize 'CHAT.OvercastReset'}}"><i class="fas fa-undo"></i></a>
-
+    <span class="overcast-count">{{test.result.overcast.available}}/{{test.result.overcast.total}}</span> {{localize "Overcasts"}} <a class="overcast-reset" title="{{localize 'CHAT.OvercastReset'}}"><i class="fas fa-undo"></i></a>
+</div>
 <div class="overcast-options">
     {{#if test.result.overcast.usage.target}}
     <div class="overcast-section">

--- a/static/templates/partials/wom-overcasts.hbs
+++ b/static/templates/partials/wom-overcasts.hbs
@@ -1,44 +1,44 @@
 <div class="card-content">
     <span class="overcast-count">{{test.result.overcast.available}}/{{test.result.overcast.total}}</span> {{localize "Overcasts"}} <a class="overcast-reset" title="{{localize 'CHAT.OvercastReset'}}"><i class="fas fa-undo"></i></a>
-    
-    <div class="overcast-options">
-    
-        {{#if test.result.overcast.usage.damage}}
-        <div class="overcast-section">
-            <a class='overcast-button' {{#unless test.result.overcast.usage.damage.available}}style = "opacity: 0.5"{{/unless}} data-overcast="damage">{{test.result.overcast.usage.damage.label}}</a>
-            <a class="overcast-value damage">{{test.result.overcast.usage.damage.current}}</a>
-        </div>
-        {{/if}}
-    
-        {{#if test.result.overcast.usage.target}}
-        <div class="overcast-section">
-            <a class='overcast-button' {{#unless test.result.overcast.usage.target.available}}style = "opacity: 0.5"{{/unless}} data-overcast="target">{{test.result.overcast.usage.target.label}}</a>
-            {{#if test.result.overcast.usage.target.AoE}}
-            <a class="overcast-value aoe-template target" data-type="diameter" data-item-id="{{test.preData.item}}" data-actor-id="{{test.actor.id}}" ><i class="fas fa-ruler-combined"></i> {{test.result.overcast.usage.target.current}} {{test.result.overcast.usage.target.unit}}</a>
-            {{else}}
-            <a class="overcast-value target">{{test.result.overcast.usage.target.current}} </a>
-            {{/if}}
-        </div>
-        {{/if}}
-        
-        {{#if test.result.overcast.usage.duration}}
-        <div class="overcast-section">
-            <a class='overcast-button' {{#unless test.result.overcast.usage.duration.available}}style = "opacity: 0.5"{{/unless}} data-overcast="duration">{{test.result.overcast.usage.duration.label}}</a>
-            <a class="overcast-value duration">{{test.result.overcast.usage.duration.current}} {{test.result.overcast.usage.duration.unit}}</a>
-        </div>
-        {{/if}}
-        
-        {{#if test.result.overcast.usage.range}}
-        <div class="overcast-section">
-            <a class='overcast-button' {{#unless test.result.overcast.usage.range.available}}style = "opacity: 0.5"{{/unless}} data-overcast="range">{{test.result.overcast.usage.range.label}}</a>
-            <a class="overcast-value range">{{test.result.overcast.usage.range.current}} {{test.result.overcast.usage.range.unit}}</a>
-        </div>
-        {{/if}}
-    
-        {{#if test.result.overcast.usage.other}}
-        <div class="overcast-section">
-            <a class='overcast-button' {{#unless test.result.overcast.usage.other.available}}style = "opacity: 0.5"{{/unless}} data-overcast="other">{{test.result.overcast.usage.other.label}}</a>
-            <a class="overcast-value other">{{test.result.overcast.usage.other.current}}</a>
-        </div>
+</div>
+<div class="overcast-options">
+
+    {{#if test.result.overcast.usage.damage}}
+    <div class="overcast-section">
+        <a class='overcast-button' {{#unless test.result.overcast.usage.damage.available}}style = "opacity: 0.5"{{/unless}} data-overcast="damage">{{test.result.overcast.usage.damage.label}}</a>
+        <a class="overcast-value damage">{{test.result.overcast.usage.damage.current}}</a>
+    </div>
+    {{/if}}
+
+    {{#if test.result.overcast.usage.target}}
+    <div class="overcast-section">
+        <a class='overcast-button' {{#unless test.result.overcast.usage.target.available}}style = "opacity: 0.5"{{/unless}} data-overcast="target">{{test.result.overcast.usage.target.label}}</a>
+        {{#if test.result.overcast.usage.target.AoE}}
+        <a class="overcast-value aoe-template target" data-type="diameter" data-item-id="{{test.preData.item}}" data-actor-id="{{test.actor.id}}" ><i class="fas fa-ruler-combined"></i> {{test.result.overcast.usage.target.current}} {{test.result.overcast.usage.target.unit}}</a>
+        {{else}}
+        <a class="overcast-value target">{{test.result.overcast.usage.target.current}} </a>
         {{/if}}
     </div>
+    {{/if}}
+    
+    {{#if test.result.overcast.usage.duration}}
+    <div class="overcast-section">
+        <a class='overcast-button' {{#unless test.result.overcast.usage.duration.available}}style = "opacity: 0.5"{{/unless}} data-overcast="duration">{{test.result.overcast.usage.duration.label}}</a>
+        <a class="overcast-value duration">{{test.result.overcast.usage.duration.current}} {{test.result.overcast.usage.duration.unit}}</a>
+    </div>
+    {{/if}}
+    
+    {{#if test.result.overcast.usage.range}}
+    <div class="overcast-section">
+        <a class='overcast-button' {{#unless test.result.overcast.usage.range.available}}style = "opacity: 0.5"{{/unless}} data-overcast="range">{{test.result.overcast.usage.range.label}}</a>
+        <a class="overcast-value range">{{test.result.overcast.usage.range.current}} {{test.result.overcast.usage.range.unit}}</a>
+    </div>
+    {{/if}}
+
+    {{#if test.result.overcast.usage.other}}
+    <div class="overcast-section">
+        <a class='overcast-button' {{#unless test.result.overcast.usage.other.available}}style = "opacity: 0.5"{{/unless}} data-overcast="other">{{test.result.overcast.usage.other.label}}</a>
+        <a class="overcast-value other">{{test.result.overcast.usage.other.current}}</a>
+    </div>
+    {{/if}}
+</div>


### PR DESCRIPTION
Hi, 

this is my second attempt to make async/sync effects fully awaitable and distinguish which ones can be async. It also adds extra awaits, mostly insides of opposed test class. If you would approve this, i could move forward with few other features that i find interesting and using them in my games: 
- awaitable sockets - which allows me to request a test from player as gm and wait with rest of effect execution once the test was completed. 
- automatic response for opposed tests from minions. When i have plenty of minor opponents like goblins, ratmans or whatever, i dont like to click too much to 'roll opposed test with weapon or skill, apply damage or effects when failed'. Instead, i have small extension that allows me to mark specific tokens as 'auto-resolve' but it requires more awaitable effects and opposed tests. 

in addition: 
- there is a fix for WoM overcast template (missing closing div). 
- fix channel until ready (again). 
- fix for hidden tokens in combat - now it syncs token status with combatant status and chat cards.

