### PR TITLE
Async effects, awaitable sockets and async/await cleanup

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "types": ["@league-of-foundry-developers/foundry-vtt-types"],
+    "moduleResolution": "node",
+    "strictNullChecks": true,
+  }
+}

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -2734,11 +2734,7 @@ export default class ActorWfrp4e extends Actor {
   rangePrefillModifiers(weapon, options, tooltip = []) {
     let modifier = 0;
 
-    let token
-    if (this.isToken)
-      token = this.token
-    else
-      token = this.getActiveTokens()[0]?.document
+    let token = this.token
 
     if (!game.settings.get("wfrp4e", "rangeAutoCalculation") || !token || !game.user.targets.size == 1 || !weapon.range?.bands)
       return 0

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -3985,6 +3985,18 @@ export default class ActorWfrp4e extends Actor {
 
   }
 
+  get token() 
+  {
+    if (super.token)
+    {
+      return super.token;
+    }
+    else 
+    {
+      return this.getActiveTokens()[0]?.document;
+    }
+  }
+
 
   // Used with Group Advantage
   // Actor is considered in the "Players" group if it is owned by a player or has a Friendly token disposition

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -2091,7 +2091,7 @@ export default class ActorWfrp4e extends Actor {
     await this.update({ "system.status.wounds.value": newWounds })
 
     if (!suppressMsg)
-      ChatMessage.create({ content: msg })
+      await ChatMessage.create({ content: msg })
     return msg;
   }
 
@@ -2941,8 +2941,7 @@ export default class ActorWfrp4e extends Actor {
 
     if (options.item && options.item.effects)
       effects = effects.concat(options.item.effects.filter(e => e.application == "item" && e.trigger == trigger))
-    for (let i = 0; i < effects.length; i++) {
-      let e = effects[i];
+    for (let e of effects) {
       game.wfrp4e.utility.runSingleEffectSync(e, this, e.item, args);
     }
     return effects;
@@ -3000,8 +2999,7 @@ export default class ActorWfrp4e extends Actor {
     }
 
     let appliedEffects = [];
-    for(let i = 0; i < effects.length; i++) {
-      let e = effects[i];
+    for (let e of effects) {
       let preArgs = {
         modifier: args?.prefillModifiers?.modifier,
         slBonus: args?.prefillModifiers?.slBonus,

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -237,12 +237,12 @@ export default class ActorWfrp4e extends Actor {
     if (!this.name) this.name = "New " + this.documentName;
     this.prepareBaseData();
     this.prepareEmbeddedDocuments();
-    this.runEffects("prePrepareData", { actor: this })
+    this.runEffectsSync("prePrepareData", { actor: this })
 
     this.prepareBaseData(); // Need to reevaluate bonuses
     this.prepareDerivedData();
 
-    this.runEffects("prePrepareItems", { actor: this })
+    this.runEffectsSync("prePrepareItems", { actor: this })
     this.prepareItems();
 
     if (this.type == "character")
@@ -257,7 +257,7 @@ export default class ActorWfrp4e extends Actor {
       this.prepareNonVehicle()
     }
 
-    this.runEffects("prepareData", { actor: this })
+    this.runEffectsSync("prepareData", { actor: this })
 
     //TODO Move prepare-updates to hooks?
     if (this.type != "vehicle") {
@@ -417,7 +417,7 @@ export default class ActorWfrp4e extends Actor {
     }
 
     let args = {size}
-    this.runEffects("calculateSize", args)
+    this.runEffectsSync("calculateSize", args)
 
     // If the size has been changed since the last known value, update the value 
     this.details.size.value = args.size || "avg"
@@ -638,7 +638,7 @@ export default class ActorWfrp4e extends Actor {
    * @param {String} characteristicId     The characteristic id (e.g. "ws") - id's can be found in config.js
    *
    */
-  setupCharacteristic(characteristicId, options = {}) {
+  async  setupCharacteristic(characteristicId, options = {}) {
     let char = this.characteristics[characteristicId];
     let title = options.title || game.i18n.format("CharTest", {char: game.i18n.localize(char.label)});
     title += options.appendTitle || "";
@@ -654,7 +654,7 @@ export default class ActorWfrp4e extends Actor {
       deadeyeShot : this.has(game.i18n.localize("NAME.DeadeyeShot"), "talent") && characteristicId == "bs"
     };
 
-    mergeObject(testData, this.getPrefillData("characteristic", characteristicId, options))
+    mergeObject(testData, await this.getPrefillData("characteristic", characteristicId, options))
 
     // Setup dialog data: title, template, buttons, prefilled data
     let dialogOptions = {
@@ -687,7 +687,7 @@ export default class ActorWfrp4e extends Actor {
     let cardOptions = this._setupCardOptions("systems/wfrp4e/templates/chat/roll/characteristic-card.hbs", title)
 
     // Provide these 3 objects to setupDialog() to create the dialog and assign the roll function
-    return this.setupDialog({
+    return await this.setupDialog({
       dialogOptions: dialogOptions,
       testData: testData,
       cardOptions: cardOptions
@@ -704,7 +704,7 @@ export default class ActorWfrp4e extends Actor {
    * @param {Object} skill    The skill item being tested. Skill items contain the advancements and the base characteristic, see template.json for more information.
    * @param {bool}   income   Whether or not the skill is being tested to determine Income.
    */
-  setupSkill(skill, options = {}) {
+  async setupSkill(skill, options = {}) {
     if (typeof (skill) === "string") {
       let skillName = skill
       skill = this.getItemTypes("skill").find(sk => sk.name == skill)
@@ -736,7 +736,7 @@ export default class ActorWfrp4e extends Actor {
       deadeyeShot : this.has(game.i18n.localize("NAME.DeadeyeShot"), "talent") && skill.characteristic.key == "bs"
     };
 
-    mergeObject(testData, this.getPrefillData("skill", skill, options))
+    mergeObject(testData, await this.getPrefillData("skill", skill, options))
 
     // Default a WS, BS, Melee, or Ranged to have hit location checked
     if ((skill.characteristic.key == "ws" ||
@@ -784,7 +784,7 @@ export default class ActorWfrp4e extends Actor {
       cardOptions.rollMode = "gmroll"
 
     // Provide these 3 objects to setupDialog() to create the dialog and assign the roll function
-    return this.setupDialog({
+    return await this.setupDialog({
       dialogOptions: dialogOptions,
       testData: testData,
       cardOptions: cardOptions
@@ -801,7 +801,7 @@ export default class ActorWfrp4e extends Actor {
    * @param {Object} weapon   The weapon Item being used.
    * @param {bool}   event    The event that called this Test, used to determine if attack is melee or ranged.
    */
-  setupWeapon(weapon, options = {}) {
+  async setupWeapon(weapon, options = {}) {
     let skillCharList = []; // This array is for the different options available to roll the test (Skills and characteristics)
     let title = options.title || game.i18n.localize("WeaponTest") + " - " + weapon.name;
     title += options.appendTitle || "";
@@ -861,11 +861,9 @@ export default class ActorWfrp4e extends Actor {
 
 
       if (weapon.loading && !weapon.loaded.value) {
-        this.rollReloadTest(weapon)
+        await this.rollReloadTest(weapon)
         ui.notifications.notify(game.i18n.localize("ErrorNotLoaded"))
-        return new Promise((resolve, reject) => {
-          resolve({ abort: true })
-        })
+        return ({ abort: true })
       }
     }
 
@@ -878,7 +876,7 @@ export default class ActorWfrp4e extends Actor {
       defaultSelection = skillCharList.findIndex(i => i.name == skillToUse.name)
     }
 
-    mergeObject(testData, this.getPrefillData("weapon", weapon, options))
+    mergeObject(testData, await this.getPrefillData("weapon", weapon, options))
 
     // Setup dialog data: title, template, buttons, prefilled data
     let dialogOptions = {
@@ -926,7 +924,7 @@ export default class ActorWfrp4e extends Actor {
     let cardOptions = this._setupCardOptions("systems/wfrp4e/templates/chat/roll/weapon-card.hbs", title)
 
     // Provide these 3 objects to setupDialog() to create the dialog and assign the roll function
-    return this.setupDialog({
+    return await this.setupDialog({
       dialogOptions: dialogOptions,
       testData: testData,
       cardOptions: cardOptions
@@ -944,7 +942,7 @@ export default class ActorWfrp4e extends Actor {
    * @param {Object} spell    The spell Item being Casted. The spell item has information like CN, lore, and current ingredient ID
    *
    */
-  setupCast(spell, options = {}) {
+  async setupCast(spell, options = {}) {
     let title = options.title || game.i18n.localize("CastingTest") + " - " + spell.name;
     title += options.appendTitle || "";
 
@@ -974,7 +972,7 @@ export default class ActorWfrp4e extends Actor {
     if (spell.damage.value)
       testData.hitLocation = true;
 
-    mergeObject(testData, this.getPrefillData("cast", spell, options))
+    mergeObject(testData, await this.getPrefillData("cast", spell, options))
 
 
     //@HOUSE
@@ -1039,7 +1037,7 @@ export default class ActorWfrp4e extends Actor {
     let cardOptions = this._setupCardOptions("systems/wfrp4e/templates/chat/roll/spell-card.hbs", title)
 
     // Provide these 3 objects to setupDialog() to create the dialog and assign the roll function
-    return this.setupDialog({
+    return await this.setupDialog({
       dialogOptions: dialogOptions,
       testData: testData,
       cardOptions: cardOptions
@@ -1057,7 +1055,7 @@ export default class ActorWfrp4e extends Actor {
    * This spell SL will then be updated accordingly.
    *
    */
-  setupChannell(spell, options = {}) {
+  async setupChannell(spell, options = {}) {
     let title = options.title || game.i18n.localize("ChannellingTest") + " - " + spell.name;
     title += options.appendTitle || "";
 
@@ -1099,7 +1097,7 @@ export default class ActorWfrp4e extends Actor {
       postFunction: "channelTest"
     };
 
-    mergeObject(testData, this.getPrefillData("channelling", spell, options))
+    mergeObject(testData, await this.getPrefillData("channelling", spell, options))
     testData.unofficialGrimoire = game.settings.get("wfrp4e", "unofficialgrimoire");
 
     // Setup dialog data: title, template, buttons, prefilled data
@@ -1150,7 +1148,7 @@ export default class ActorWfrp4e extends Actor {
     let cardOptions = this._setupCardOptions("systems/wfrp4e/templates/chat/roll/channel-card.hbs", title)
 
     // Provide these 3 objects to setupDialog() to create the dialog and assign the roll function
-    return this.setupDialog({
+    return await this.setupDialog({
       dialogOptions: dialogOptions,
       testData: testData,
       cardOptions: cardOptions
@@ -1167,7 +1165,7 @@ export default class ActorWfrp4e extends Actor {
    * @param {Object} prayer    The prayer Item being used, compared to spells, not much information
    * from the prayer itself is needed.
    */
-  setupPrayer(prayer, options = {}) {
+  async setupPrayer(prayer, options = {}) {
     let title = options.title || game.i18n.localize("PrayerTest") + " - " + prayer.name;
     title += options.appendTitle || "";
 
@@ -1200,7 +1198,7 @@ export default class ActorWfrp4e extends Actor {
       testData.hitLocation = true;
 
 
-    mergeObject(testData, this.getPrefillData("prayer", prayer, options))
+    mergeObject(testData, await this.getPrefillData("prayer", prayer, options))
 
 
     // Setup dialog data: title, template, buttons, prefilled data
@@ -1236,7 +1234,7 @@ export default class ActorWfrp4e extends Actor {
     let cardOptions = this._setupCardOptions("systems/wfrp4e/templates/chat/roll/prayer-card.hbs", title)
 
     // Provide these 3 objects to setupDialog() to create the dialog and assign the roll function
-    return this.setupDialog({
+    return await this.setupDialog({
       dialogOptions: dialogOptions,
       testData: testData,
       cardOptions: cardOptions
@@ -1253,7 +1251,7 @@ export default class ActorWfrp4e extends Actor {
    *
    * @param {Object} trait   The trait Item being used, containing which characteristic/bonus characteristic to use
    */
-  setupTrait(trait, options = {}) {
+  async setupTrait(trait, options = {}) {
     if (!trait.id)
       trait = new CONFIG.Item.documentClass(trait, { parent: this })
 
@@ -1287,7 +1285,7 @@ export default class ActorWfrp4e extends Actor {
     else 
       testData.hitLocation = "none"
 
-    mergeObject(testData, this.getPrefillData("trait", trait, options))
+    mergeObject(testData, await this.getPrefillData("trait", trait, options))
 
 
     // Setup dialog data: title, template, buttons, prefilled data
@@ -1325,7 +1323,7 @@ export default class ActorWfrp4e extends Actor {
     let cardOptions = this._setupCardOptions("systems/wfrp4e/templates/chat/roll/weapon-card.hbs", title)
 
     // Provide these 3 objects to setupDialog() to create the dialog and assign the roll function
-    return this.setupDialog({
+    return await this.setupDialog({
       dialogOptions: dialogOptions,
       testData: testData,
       cardOptions: cardOptions
@@ -1333,7 +1331,7 @@ export default class ActorWfrp4e extends Actor {
   }
 
 
-  setupExtendedTest(item, options = {}) {
+  async setupExtendedTest(item, options = {}) {
 
     let defaultRollMode = item.hide.test || item.hide.progress ? "gmroll" : "roll"
 
@@ -1347,18 +1345,18 @@ export default class ActorWfrp4e extends Actor {
 
     let characteristic = WFRP_Utility.findKey(item.test.value, game.wfrp4e.config.characteristics)
     if (characteristic) {
-      return this.setupCharacteristic(characteristic, options).then(setupData => {
-        this.basicTest(setupData)
-      })
+      let test = await this.setupCharacteristic(characteristic, options);
+      await test.roll();
     }
     else {
       let skill = this.getItemTypes("skill").find(i => i.name == item.test.value)
       if (skill) {
-        return this.setupSkill(skill, options).then(setupData => {
-          this.basicTest(setupData)
-        })
+        let test = await this.setupSkill(skill, options);
+        await test.roll();
+      } 
+      else {
+        ui.notifications.error(`${game.i18n.format("ExtendedError2", { name: item.test.value })}`)
       }
-      ui.notifications.error(`${game.i18n.format("ExtendedError2", { name: item.test.value })}`)
     }
   }
 
@@ -1424,16 +1422,16 @@ export default class ActorWfrp4e extends Actor {
   }
 
 
-  rollReloadTest(weapon) {
+  async rollReloadTest(weapon) {
     let testId = weapon.getFlag("wfrp4e", "reloading")
     let extendedTest = this.items.get(testId)
     if (!extendedTest) {
 
       //ui.notifications.error(game.i18n.localize("ITEM.ReloadError"))
-      this.checkReloadExtendedTest(weapon);
+      await this.checkReloadExtendedTest(weapon);
       return
     }
-    this.setupExtendedTest(extendedTest, { reload: true, weapon, appendTitle: " - " + game.i18n.localize("ITEM.Reloading") });
+    await this.setupExtendedTest(extendedTest, { reload: true, weapon, appendTitle: " - " + game.i18n.localize("ITEM.Reloading") });
   }
 
 
@@ -1588,7 +1586,7 @@ export default class ActorWfrp4e extends Actor {
     }
 
     let args = {AP}
-    this.runEffects("preAPCalc", args);
+    this.runEffectsSync("preAPCalc", args);
 
     this.getItemTypes("armour").filter(a => a.isEquipped).forEach(a => a._addAPLayer(AP))
 
@@ -1597,7 +1595,7 @@ export default class ActorWfrp4e extends Actor {
       AP.shieldDamage += i.damageToItem.shield;
     })
 
-    this.runEffects("APCalc", args);
+    this.runEffectsSync("APCalc", args);
 
     this.status.armour = AP
   }
@@ -1639,17 +1637,16 @@ export default class ActorWfrp4e extends Actor {
   }
 
   // Resize tokens based on size property
-  checkSize()
+  async checkSize()
   {
     if (this.flags.autoCalcSize && game.canvas.ready) {
       let tokenData = this._getTokenSize();
       if (this.isToken) {
-        return this.token.update(tokenData)
+        await this.token.update(tokenData)
       }
       else if (canvas) {
-        return this.update({prototypeToken : tokenData}).then(() => {
-          this.getActiveTokens().forEach(t => t.document.update(tokenData));
-        })
+        await this.update({prototypeToken : tokenData});
+        this.getActiveTokens().forEach(t => t.document.update(tokenData));
       }
     } 
   }
@@ -1696,7 +1693,7 @@ export default class ActorWfrp4e extends Actor {
       this.status.criticalWounds.max = tb;
 
     let effectArgs = { sb, tb, wpb, multiplier, actor: this }
-    this.runEffects("preWoundCalc", effectArgs);
+    this.runEffectsSync("preWoundCalc", effectArgs);
     ({ sb, tb, wpb } = effectArgs);
 
     let wounds = this.status.wounds.max;
@@ -1735,7 +1732,7 @@ export default class ActorWfrp4e extends Actor {
     }
 
     effectArgs = { wounds, actor: this }
-    this.runEffects("woundCalc", effectArgs);
+    this.runEffectsSync("woundCalc", effectArgs);
     wounds = effectArgs.wounds;
     return wounds
   }
@@ -1752,7 +1749,7 @@ export default class ActorWfrp4e extends Actor {
    * @param {Object} opposedData  Test results, all the information needed to calculate damage
    * @param {var}    damageType   enum for what the damage ignores, see config.js
    */
-  applyDamage(opposedTest, damageType = game.wfrp4e.config.DAMAGE_TYPE.NORMAL) {
+  async applyDamage(opposedTest, damageType = game.wfrp4e.config.DAMAGE_TYPE.NORMAL) {
     if (!opposedTest.result.damage)
       return `<b>Error</b>: ${game.i18n.localize("CHAT.DamageAppliedError")}`
     // If no damage value, don't attempt anything
@@ -1793,8 +1790,8 @@ export default class ActorWfrp4e extends Actor {
     let pummel = false
 
     let args = { actor, attacker, opposedTest, damageType, weaponProperties, applyAP, applyTB, totalWoundLoss, AP, extraMessages }
-    actor.runEffects("preTakeDamage", args)
-    attacker.runEffects("preApplyDamage", args)
+    await actor.runEffectsAsync("preTakeDamage", args)
+    await attacker.runEffectsAsync("preApplyDamage", args)
     damageType = args.damageType
     applyAP = args.applyAP 
     applyTB = args.applyTB
@@ -1938,14 +1935,14 @@ export default class ActorWfrp4e extends Actor {
     }
 
     let scriptArgs = { actor, opposedTest, totalWoundLoss, AP, damageType, updateMsg, messageElements, attacker, extraMessages }
-    actor.runEffects("takeDamage", scriptArgs)
-    attacker.runEffects("applyDamage", scriptArgs)
+    await actor.runEffectsAsync("takeDamage", scriptArgs)
+    await attacker.runEffectsAsync("applyDamage", scriptArgs)
     Hooks.call("wfrp4e:applyDamage", scriptArgs)
 
     let item = opposedTest.attackerTest.item
     let itemDamageEffects = item.damageEffects
     for (let effect of itemDamageEffects) {      
-      game.wfrp4e.utility.runSingleEffect(effect, actor, item, scriptArgs);
+      await game.wfrp4e.utility.runSingleEffectAsync(effect, actor, item, scriptArgs);
     }
     totalWoundLoss = scriptArgs.totalWoundLoss
 
@@ -2498,7 +2495,7 @@ export default class ActorWfrp4e extends Actor {
    * @param {Object} item   For when an object is being used, such as any test except characteristic
    * @param {*} options     Optional parameters, such as if "resting", or if testing for corruption
    */
-  getPrefillData(type, item, options = {}) {
+  async getPrefillData(type, item, options = {}) {
     let modifier = 0,
       difficulty = "challenging",
       slBonus = 0,
@@ -2607,10 +2604,10 @@ export default class ActorWfrp4e extends Actor {
       }
 
       let effectModifiers = { modifier, difficulty, slBonus, successBonus }
-      let effects = this.runEffects("prefillDialog", { prefillModifiers: effectModifiers, type, item, options })
+      let effects = await this.runEffectsAsync("prefillDialog", { prefillModifiers: effectModifiers, type, item, options })
       tooltip = tooltip.concat(effects.map(e => e.tooltip));
       if (game.user.targets.size) {
-        effects = this.runEffects("targetPrefillDialog", { prefillModifiers: effectModifiers, type, item, options })
+        effects = await this.runEffectsAsync("targetPrefillDialog", { prefillModifiers: effectModifiers, type, item, options })
         tooltip = tooltip.concat(effects.map(e => `${game.i18n.localize("EFFECT.Target")} ${e.tooltip}`));
       }
 
@@ -2924,9 +2921,20 @@ export default class ActorWfrp4e extends Actor {
     return modifier;
   }
 
+  runEffectsSync(trigger, args, options = {}) {
+    let effects = this.actorEffects.filter(e => e.trigger == trigger && (e.script ?? e.flags.wfrp4e.script) && !e.disabled)
+
+    if (options.item && options.item.effects)
+      effects = effects.concat(options.item.effects.filter(e => e.application == "item" && e.trigger == trigger))
+    for (let i = 0; i < effects.length; i++) {
+      let e = effects[i];
+      game.wfrp4e.utility.runSingleEffectSync(e, this, e.item, args);
+    }
+    return effects;
+  }
 
 
-  runEffects(trigger, args, options = {}) {
+  async runEffectsAsync(trigger, args, options = {}) {
     // WFRP_Utility.log(`${this.name} > Effect Trigger ${trigger}`)
     let effects = this.actorEffects.filter(e => e.trigger == trigger && (e.script ?? e.flags.wfrp4e.script) && !e.disabled)
 
@@ -2939,7 +2947,6 @@ export default class ActorWfrp4e extends Actor {
         effects.push(loreEffect);
       }
     }
-
 
     // These triggers have a special case where they can specify a specific item to run on
     // If this choice (itemChoice) matches the provided item argument, keep it, otherwise, filter out
@@ -2963,7 +2970,7 @@ export default class ActorWfrp4e extends Actor {
     if (trigger == "oneTime") {
       effects = effects.filter(e => e.application != "apply" && e.application != "damage");
       if (effects.length)
-        this.deleteEmbeddedDocuments("ActiveEffect", effects.map(e => e.id))
+        await this.deleteEmbeddedDocuments("ActiveEffect", effects.map(e => e.id))
     }
 
     if (trigger == "targetPrefillDialog" && game.user.targets.size) {
@@ -2978,7 +2985,8 @@ export default class ActorWfrp4e extends Actor {
     }
 
     let appliedEffects = [];
-    effects.forEach(e => {
+    for(let i = 0; i < effects.length; i++) {
+      let e = effects[i];
       let preArgs = {
         modifier: args?.prefillModifiers?.modifier,
         slBonus: args?.prefillModifiers?.slBonus,
@@ -2986,7 +2994,7 @@ export default class ActorWfrp4e extends Actor {
         difficulty: args?.prefillModifiers?.difficulty
       };
       
-      game.wfrp4e.utility.runSingleEffect(e, this, e.item, args, options);
+      await game.wfrp4e.utility.runSingleEffectAsync(e, this, e.item, args, options);
 
       if(trigger == "targetPrefillDialog" || trigger == "prefillDialog") {
         this._handleTooltipDiff(e, preArgs, args)
@@ -2998,7 +3006,7 @@ export default class ActorWfrp4e extends Actor {
       else {
         appliedEffects.push(e);
       }
-    })
+    }
     return appliedEffects;
   }
 
@@ -3144,7 +3152,7 @@ export default class ActorWfrp4e extends Actor {
     }
     else {
       await this.deleteEmbeddedDocuments("ActiveEffect", [removeEffects])
-      this.deleteEffectsFromItem(disease._id)
+      await this.deleteEffectsFromItem(disease._id)
     }
     let chatData = game.wfrp4e.utility.chatDataSetup(msg, "gmroll", false)
     chatData.speaker = { alias: this.name }
@@ -3368,14 +3376,14 @@ export default class ActorWfrp4e extends Actor {
 
   }
 
-  deleteEffectsFromItem(itemId) {
+  async deleteEffectsFromItem(itemId) {
     let removeEffects = this.effects.filter(e => {
       if (!e.origin)
         return false
       return e.origin.includes(itemId)
     }).map(e => e.id).filter(id => this.actorEffects.has(id))
 
-    this.deleteEmbeddedDocuments("ActiveEffect", removeEffects)
+    await this.deleteEmbeddedDocuments("ActiveEffect", removeEffects)
 
   }
 
@@ -3419,7 +3427,7 @@ export default class ActorWfrp4e extends Actor {
         item.system.SL.current = 0;
       else if (item.system.completion.value == "remove") {
         await this.deleteEmbeddedDocuments("Item", [item._id])
-        this.deleteEffectsFromItem(item._id)
+        await this.deleteEffectsFromItem(item._id)
         item = undefined
       }
       displayString = displayString.concat(`<br><b>${game.i18n.localize("Completed")}</b>`)
@@ -3431,7 +3439,7 @@ export default class ActorWfrp4e extends Actor {
       this.updateEmbeddedDocuments("Item", [item]);
   }
 
-  checkReloadExtendedTest(weapon) {
+  async checkReloadExtendedTest(weapon) {
 
     if (!weapon.loading)
       return
@@ -3440,9 +3448,10 @@ export default class ActorWfrp4e extends Actor {
 
     if (weapon.loaded.amt > 0) {
       if (reloadingTest) {
-        reloadingTest.delete()
-        weapon.update({ "flags.wfrp4e.-=reloading": null })
-        return ui.notifications.notify(game.i18n.localize("ITEM.ReloadFinish"))
+        await reloadingTest.delete()
+        await weapon.update({ "flags.wfrp4e.-=reloading": null })
+        ui.notifications.notify(game.i18n.localize("ITEM.ReloadFinish"))
+        return;
       }
     }
     else {
@@ -3472,15 +3481,12 @@ export default class ActorWfrp4e extends Actor {
       }
 
       if (reloadingTest)
-        reloadingTest.delete()
+        await reloadingTest.delete()
 
-      this.createEmbeddedDocuments("Item", [reloadExtendedTest]).then(item => {
-        ui.notifications.notify(game.i18n.format("ITEM.CreateReloadTest", { weapon: weapon.name }))
-        weapon.update({ "flags.wfrp4e.reloading": item[0].id })
-      })
+      let item = await this.createEmbeddedDocuments("Item", [reloadExtendedTest]);
+      ui.notifications.notify(game.i18n.format("ITEM.CreateReloadTest", { weapon: weapon.name }))
+      await weapon.update({ "flags.wfrp4e.reloading": item[0].id });
     }
-
-
   }
 
 
@@ -3873,8 +3879,8 @@ export default class ActorWfrp4e extends Actor {
     return (this.itemCategories || this.itemTypes)[type]
   }
 
-  clearOpposed() {
-    return this.update({ "flags.-=oppose": null })
+  async clearOpposed() {
+    await this.update({ "flags.-=oppose": null })
   }
 
   /**

--- a/modules/actor/sheet/actor-sheet.js
+++ b/modules/actor/sheet/actor-sheet.js
@@ -1262,7 +1262,7 @@ export default class ActorSheetWfrp4e extends ActorSheet {
           Yes: {
             icon: '<i class="fa fa-check"></i>', label: game.i18n.localize("Yes"), callback: async dlg => {
               await this.actor.deleteEmbeddedDocuments("Item", [itemId]);
-              this.actor.deleteEffectsFromItem(itemId)
+              await this.actor.deleteEffectsFromItem(itemId);
               li.slideUp(200, () => this.render(false))
             }
           }, cancel: { icon: '<i class="fas fa-times"></i>', label: game.i18n.localize("Cancel") },
@@ -1418,9 +1418,9 @@ export default class ActorSheetWfrp4e extends ActorSheet {
       return
     }
     if (ev.button == 0)
-      this.actor.addCondition(condKey)
+      await this.actor.addCondition(condKey)
     else if (ev.button == 2)
-      this.actor.removeCondition(condKey)
+      await this.actor.removeCondition(condKey)
   }
   async _onSpeciesEdit(ev) {
     let input = ev.target.value;
@@ -2127,13 +2127,13 @@ export default class ActorSheetWfrp4e extends ActorSheet {
       let effectId = ev.target.dataset["effectId"]
       let itemId = ev.target.dataset["itemId"]
 
-      let effect = this.actor.populateEffect(effectId, itemId)
+      let effect =  await this.actor.populateEffect(effectId, itemId)
       let item = this.actor.items.get(itemId)
 
       if (effect.flags.wfrp4e?.reduceQuantity)
       {
         if (item.quantity.value > 0)
-          item.update({"system.quantity.value" : item.quantity.value - 1})
+          await item.update({"system.quantity.value" : item.quantity.value - 1})
         else 
           throw ui.notifications.error(game.i18n.localize("EFFECT.QuantityError"))
       }

--- a/modules/actor/sheet/actor-sheet.js
+++ b/modules/actor/sheet/actor-sheet.js
@@ -1235,14 +1235,14 @@ export default class ActorSheetWfrp4e extends ActorSheet {
   }
 
 
-  _onEffectTarget(ev) {
+  async _onEffectTarget(ev) {
     let id = $(ev.currentTarget).parents(".item").attr("data-item-id");
     
-    let effect = this.actor.populateEffect(id);
+    let effect = await this.actor.populateEffect(id);
     if (effect.trigger == "apply")
-      game.wfrp4e.utility.applyEffectToTarget(effect)
+      await game.wfrp4e.utility.applyEffectToTarget(effect)
     else {
-      game.wfrp4e.utility.runSingleEffect(effect, this.actor, effect.item, {actor : this.actor, effect, item : effect.item});
+      await game.wfrp4e.utility.runSingleEffectAsync(effect, this.actor, effect.item, {actor : this.actor, effect, item : effect.item});
     }
   }
 
@@ -1401,19 +1401,20 @@ export default class ActorSheetWfrp4e extends ActorSheet {
       }).render(true)
     }
   }
-  _onConditionValueClicked(ev) {
+  async _onConditionValueClicked(ev) {
     let condKey = $(ev.currentTarget).parents(".sheet-condition").attr("data-cond-id")
     if (ev.button == 0)
-      this.actor.addCondition(condKey)
+      await this.actor.addCondition(condKey)
     else if (ev.button == 2)
-      this.actor.removeCondition(condKey)
+      await this.actor.removeCondition(condKey)
   }
-  _onConditionToggle(ev) {
+  async _onConditionToggle(ev) {
     let condKey = $(ev.currentTarget).parents(".sheet-condition").attr("data-cond-id")
     if (game.wfrp4e.config.statusEffects.find(e => e.id == condKey).flags.wfrp4e.value == null) {
       if (this.actor.hasCondition(condKey))
-        this.actor.removeCondition(condKey)
-      else this.actor.addCondition(condKey)
+        await this.actor.removeCondition(condKey)
+      else 
+        await this.actor.addCondition(condKey)
       return
     }
     if (ev.button == 0)
@@ -2138,9 +2139,9 @@ export default class ActorSheetWfrp4e extends ActorSheet {
       }
 
       if ((item.range && item.range.value.toLowerCase() == game.i18n.localize("You").toLowerCase()) && (item.target && item.target.value.toLowerCase() == game.i18n.localize("You").toLowerCase()))
-        game.wfrp4e.utility.applyEffectToTarget(effect, [{ actor: this.actor }]) // Apply to caster (self) 
+        await game.wfrp4e.utility.applyEffectToTarget(effect, [{ actor: this.actor }]) // Apply to caster (self) 
       else
-        game.wfrp4e.utility.applyEffectToTarget(effect)
+        await game.wfrp4e.utility.applyEffectToTarget(effect)
     })
 
     html.on("click", ".invoke-effect", async ev => {

--- a/modules/actor/sheet/actor-sheet.js
+++ b/modules/actor/sheet/actor-sheet.js
@@ -531,20 +531,20 @@ export default class ActorSheetWfrp4e extends ActorSheet {
               label: game.i18n.localize("Channel"),
               callback: async btn => {
                 let test = await this.actor.setupChannell(spell, options);
+                await test.roll();
                 if (test.context.channelUntilSuccess) {
-                   do {
-                    let testObject = duplicate(test);
-                    let testDuplicate = test.constructor.recreate(testObject.data);
+                  await WFRP_Utility.sleep(200);
+                  do {
                     if (test.item.cn.SL >= test.item.cn.value) {
                       break;
                     }
-                    if (testDuplicate.result.minormis || testDuplicate.result.majormis || testDuplicate.result.catastrophicmis) {
+                    if (test.result.minormis || test.result.majormis || test.result.catastrophicmis) {
                       break;
                     }
-                    await testDuplicate.roll();
+                    test.context.messageId = null; // Clear message so new message is made
+                    await test.roll();
+                    await WFRP_Utility.sleep(200);
                   } while (true);
-                } else {
-                  await test.roll();
                 }
               }
             }

--- a/modules/apps/active-effect.js
+++ b/modules/apps/active-effect.js
@@ -19,7 +19,7 @@ export default class WFRPActiveEffectConfig extends ActiveEffectConfig {
         {
             data.showEditor = true;
             data.placeholder = game.wfrp4e.config.effectPlaceholder[type] + game.wfrp4e.config.effectPlaceholder.this
-            if (WFRP_Utility.syncEffectTriggers.indexOf(type) === -1)
+            if (game.wfrp4e.config.syncEffectTriggers.indexOf(type) === -1)
                 data.showIsAsync = true;
         }
 

--- a/modules/apps/active-effect.js
+++ b/modules/apps/active-effect.js
@@ -21,6 +21,17 @@ export default class WFRPActiveEffectConfig extends ActiveEffectConfig {
             data.placeholder = game.wfrp4e.config.effectPlaceholder[type] + game.wfrp4e.config.effectPlaceholder.this
         }
 
+        if (type == "prepareItem" || type == "prePrepareItem")
+        {
+            data.promptChoice = true;
+        }
+
+        if (this.object.flags.wfrp4e.promptItem)
+        {
+            data.showExtra = true;
+            data.extraPlaceholder = game.i18n.localize("EFFECT.ItemFilters");
+        }
+
         data.effectApplication = duplicate(game.wfrp4e.config.effectApplication)
         if (this.object.parent.documentName == "Item")
         {
@@ -111,6 +122,10 @@ export default class WFRPActiveEffectConfig extends ActiveEffectConfig {
             if (ev.target.value == "invoke")
                 this.effectTriggerSelect.value = ""
                 
+            this.submit({preventClose : true})
+        })
+
+        this.effectApplicationSelect = html.find("input").change(ev => {
             this.submit({preventClose : true})
         })
     }   

--- a/modules/apps/active-effect.js
+++ b/modules/apps/active-effect.js
@@ -19,6 +19,8 @@ export default class WFRPActiveEffectConfig extends ActiveEffectConfig {
         {
             data.showEditor = true;
             data.placeholder = game.wfrp4e.config.effectPlaceholder[type] + game.wfrp4e.config.effectPlaceholder.this
+            if (WFRP_Utility.syncEffectTriggers.indexOf(type) === -1)
+                data.showIsAsync = true;
         }
 
         if (type == "prepareItem" || type == "prePrepareItem")

--- a/modules/apps/chargen/char-gen.js
+++ b/modules/apps/chargen/char-gen.js
@@ -311,17 +311,12 @@ export default class CharGenWfrp4e extends FormApplication {
         document.sheet.render(true);
       }
       else {
-        game.socket.emit("system.wfrp4e", {type: "createActor", payload : {id : game.user.id, data : this.actor, items : items.map(i => i instanceof Item ? i.toObject() : i)}})
-
-        // Sockets don't have a callback so wait 1 second then try to open the sheet
-        // Not pretty but...whatever
-        setTimeout(() => {
-          let actor = game.actors.getName(this.actor.name)
-          if (actor && actor.isOwner)
-          {
-            actor.sheet.render(true)
-          }
-        }, 1000)
+        const payload =  {id : game.user.id, data : this.actor, items : items.map(i => i instanceof Item ? i.toObject() : i)}
+        await WFRP_Utility.awaitSocket(game.user, "createActor", payload, "Creating actor");
+        let actor = game.actors.getName(this.actor.name)
+        if (actor && actor.isOwner) {
+          actor.sheet.render(true)
+        }
       }
     }
     catch(e)

--- a/modules/hooks/activeEffects.js
+++ b/modules/hooks/activeEffects.js
@@ -43,7 +43,7 @@ export default function () {
 
         if (effect.parent?.documentName == "Actor" && effect.application == "apply")
         {
-            effect.updateSource({"flags.wfrp4e.effectApplication" : "actor"})
+            await effect.updateSource({"flags.wfrp4e.effectApplication" : "actor"})
         }
 
         if (effect.parent?.documentName == "Actor" && effect.trigger == "oneTime")
@@ -52,7 +52,6 @@ export default function () {
             await game.wfrp4e.utility.applyOneTimeEffect(effect, effect.parent);
             return false
         }
-                
     })
 
 }
@@ -66,6 +65,6 @@ async function _runUpdateEffects(effect, context, options, id)
 
     if (effect.parent?.documentName == "Actor")
     {
-        await effect.parent.runEffects("update", {effect, context});
+        await effect.parent.runEffectsAsync("update", {effect, context});
     }
 }

--- a/modules/hooks/activeEffects.js
+++ b/modules/hooks/activeEffects.js
@@ -1,22 +1,22 @@
 
 export default function () {
 
-    Hooks.on("createActiveEffect", (effect, options, id) => {_runUpdateEffects(effect, "create", options, id)})
-    Hooks.on("updateActiveEffect", (effect, options, id) => {_runUpdateEffects(effect, "update", options, id)})
-    Hooks.on("deleteActiveEffect", (effect, options, id) => {
+    Hooks.on("createActiveEffect", async (effect, options, id) => {await _runUpdateEffects(effect, "create", options, id)})
+    Hooks.on("updateActiveEffect", async (effect, options, id) => {await _runUpdateEffects(effect, "update", options, id)})
+    Hooks.on("deleteActiveEffect", async (effect, options, id) => {
         if (effect.parent.documentName == "Actor")
         {
             let items = effect.parent.items.filter(i => i.getFlag("wfrp4e", "fromEffect") == effect.id);
             if (items.length)
             {
                 ui.notifications.notify(game.i18n.format("EFFECT.DeletingItems", {items : items.map(i => i.name).join(", ")}))
-                effect.parent.deleteEmbeddedDocuments("Item", items.map(i => i.id));
+                await effect.parent.deleteEmbeddedDocuments("Item", items.map(i => i.id));
             }
         }
-        _runUpdateEffects(effect, "delete", options, id)
+        await _runUpdateEffects(effect, "delete", options, id)
     })
 
-    Hooks.on("preCreateActiveEffect", (effect, data, options, id) => {
+    Hooks.on("preCreateActiveEffect", async (effect, data, options, id) => {
 
         if (getProperty(effect, "flags.wfrp4e.preventDuplicateEffects"))
         {
@@ -29,7 +29,7 @@ export default function () {
 
         if (effect.parent?.documentName == "Actor" && effect.trigger == "addItems")
         {
-            game.wfrp4e.utility.applyOneTimeEffect(effect, effect.parent);
+            await game.wfrp4e.utility.applyOneTimeEffect(effect, effect.parent);
             options.keepId = true;
         }
         
@@ -49,7 +49,7 @@ export default function () {
         if (effect.parent?.documentName == "Actor" && effect.trigger == "oneTime")
         {
             ui.notifications.notify(`${game.i18n.format("EFFECT.Applying", { name: effect.label })}`)
-            game.wfrp4e.utility.applyOneTimeEffect(effect, effect.parent);
+            await game.wfrp4e.utility.applyOneTimeEffect(effect, effect.parent);
             return false
         }
                 
@@ -57,7 +57,7 @@ export default function () {
 
 }
 
-function _runUpdateEffects(effect, context, options, id)
+async function _runUpdateEffects(effect, context, options, id)
 {
     if (id != game.user.id)
     {
@@ -66,6 +66,6 @@ function _runUpdateEffects(effect, context, options, id)
 
     if (effect.parent?.documentName == "Actor")
     {
-        effect.parent.runEffects("update", {effect, context}, {async: true})
+        await effect.parent.runEffects("update", {effect, context});
     }
 }

--- a/modules/hooks/actor.js
+++ b/modules/hooks/actor.js
@@ -1,14 +1,14 @@
 export default function() {
 
 
-    Hooks.on("updateActor", (actor) =>{
-        actor.runEffects("update", {}, {async: true})
-        actor.checkSize();
+    Hooks.on("updateActor", async (actor) =>{
+        await actor.runEffectsAsync("update", {})
+        await actor.checkSize();
 
     })
 
-    Hooks.on("createActor", (actor) =>{
-        actor.runEffects("update", {}, {async: true})
-        actor.checkSize();
+    Hooks.on("createActor", async (actor) =>{
+        await actor.runEffectsAsync("update", {})
+        await actor.checkSize();
     })
 }

--- a/modules/hooks/chat.js
+++ b/modules/hooks/chat.js
@@ -337,7 +337,6 @@ export default function() {
         if (app.flags.postQuantity == "inf" || app.flags.postQuantity == undefined)
           return ev.dataTransfer.setData("text/plain", app.flags.transfer);
 
-
         if (game.user.isGM)
         {
           ev.dataTransfer.setData("text/plain", app.flags.transfer);

--- a/modules/hooks/entryContext.js
+++ b/modules/hooks/entryContext.js
@@ -133,7 +133,7 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamage"),
         icon: '<i class="fas fa-user-minus"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
 
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
@@ -146,8 +146,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -155,7 +155,7 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamageNoAP"),
         icon: '<i class="fas fa-user-shield"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
             canvas.tokens.controlled.map(i => i.document.actor).concat(Array.from(game.user.targets).map(i => i.document.actor)).forEach(a => a.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_AP }))
@@ -167,8 +167,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_AP)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_AP)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -176,7 +176,7 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamageNoTB"),
         icon: '<i class="fas fa-fist-raised"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
             canvas.tokens.controlled.map(i => i.document.actor).concat(Array.from(game.user.targets).map(i => i.document.actor)).forEach(a => a.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_TB }))
@@ -188,8 +188,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_TB)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_TB)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -197,7 +197,7 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyDamageNoTBAP"),
         icon: '<i class="fas fa-skull-crossbones"></i>',
         condition: canApply,
-        callback: li => {
+        callback: async li => {
           if (li.find(".dice-roll").length) {
             let amount = li.find('.dice-total').text();
             canvas.tokens.controlled.map(i => i.document.actor).concat(Array.from(game.user.targets).map(i => i.document.actor)).forEach(a => a.applyBasicDamage(amount, { damageType: game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL }))
@@ -209,8 +209,8 @@ export default function () {
             if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
 
-            let updateMsg = opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL)
-            OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
+            let updateMsg = await opposedTest.defenderTest.actor.applyDamage(opposedTest, game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL)
+            await OpposedWFRP.updateOpposedMessage(updateMsg, message.id);
           }
         }
       },
@@ -290,11 +290,10 @@ export default function () {
         name: game.i18n.localize("CHATOPT.ApplyAllDamage"),
         icon: '<i class="fas fa-user-minus"></i>',
         condition: canApplyAllDamage,
-        callback: li => {
-
+        callback: async li => {
           let message = game.messages.get(li.attr("data-message-id"));
           let test = message.getTest();
-          test.opposedMessages.forEach(message => {
+          for (let message of test.opposedMessages) {
             if (message)
             {
 
@@ -303,10 +302,10 @@ export default function () {
               if (!opposedTest.defenderTest.actor.isOwner)
               return ui.notifications.error(game.i18n.localize("ErrorDamagePermission"))
               
-              let updateMsg = opposedTest.defender.applyDamage(opposedTest.resultMessage.getOpposedTest(), game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
-              OpposedWFRP.updateOpposedMessage(updateMsg, opposedTest.resultMessage.id);
+              let updateMsg = await opposedTest.defender.applyDamage(opposedTest.resultMessage.getOpposedTest(), game.wfrp4e.config.DAMAGE_TYPE.NORMAL)
+              await OpposedWFRP.updateOpposedMessage(updateMsg, opposedTest.resultMessage.id);
             }
-          })
+          }
         }
       }
     )

--- a/modules/hooks/handlebars.js
+++ b/modules/hooks/handlebars.js
@@ -27,21 +27,13 @@ export default function () {
         })
 
         Handlebars.registerHelper("tokenImg", function(actor) {
-            let tokens = actor.getActiveTokens();
-            let tokenDocument = actor.prototypeToken;
-            if(tokens.length == 1) {
-                tokenDocument = tokens[0].document;
-            }
-            return tokenDocument.hidden ? "systems/wfrp4e/tokens/unknown.png" : tokenDocument.texture.src;
+            let token = actor.token
+            return token.hidden ? "systems/wfrp4e/tokens/unknown.png" : token?.texture?.src;
         })
 
         Handlebars.registerHelper("tokenName", function(actor) {
-            let tokens = actor.getActiveTokens();
-            let tokenDocument = actor.prototypeToken;
-            if(tokens.length == 1) {
-                tokenDocument = tokens[0].document;
-            }
-            return tokenDocument.hidden ? "???" : tokenDocument.name;
+            let token = actor.token
+            return token?.hidden ? "???" : token?.name;
         })
 
         Handlebars.registerHelper("settings", function (key) {

--- a/modules/hooks/item.js
+++ b/modules/hooks/item.js
@@ -4,10 +4,9 @@ export default function () {
   Hooks.on("updateItem", async (item, update, options, id) => {
 
     if (game.user.id != id)
-    return
+      return
 
-    if (item.actor)
-    {
+    if (item.actor) {
       await item.actor.runEffectsAsync("update", {item, context: "update"})
     }
 
@@ -16,7 +15,7 @@ export default function () {
       if (formsLoop(item, allContainers))
       {
         ui.notifications.error("Loop formed - Resetting Container Location")
-        return item.update({ "system.location.value": "" })
+        await item.update({ "system.location.value": "" })
       }
     }
 
@@ -96,10 +95,9 @@ export default function () {
 
   Hooks.on("deleteItem", async (item, options, id) => {
     if (game.user.id != id)
-    return
+      return
 
-    if (item.actor)
-    {
+    if (item.actor) {
       await item.actor.runEffectsAsync("update", {item, context: "delete"});
     }
   })

--- a/modules/hooks/item.js
+++ b/modules/hooks/item.js
@@ -1,14 +1,14 @@
 
 export default function () {
 
-  Hooks.on("updateItem", (item, update, options, id) => {
+  Hooks.on("updateItem", async (item, update, options, id) => {
 
     if (game.user.id != id)
     return
 
     if (item.actor)
     {
-      item.actor.runEffects("update", {item, context: "update"}, {async: true})
+      await item.actor.runEffectsAsync("update", {item, context: "update"})
     }
 
     if (item.type == "container" && update.system?.location?.value) {
@@ -49,7 +49,7 @@ export default function () {
    * Criticals - apply wound values
    * 
    */
-  Hooks.on("createItem", (item, options, id) => {
+  Hooks.on("createItem", async (item, options, id) => {
 
     if (game.user.id != id)
       return
@@ -57,7 +57,7 @@ export default function () {
     if (!item.isOwned)
       return
 
-    item.actor.runEffects("update", {item, context: "create"}, {async: true})
+    await item.actor.runEffectsAsync("update", {item, context: "create"})
 
     if (item.actor.type == "vehicle")
       return;
@@ -75,12 +75,13 @@ export default function () {
         } else if (item.wounds.value.toLowerCase() == "death") {
           newWounds = 0;
         }
-        item.actor.update({ "system.status.wounds.value": newWounds });
+        await item.actor.update({ "system.status.wounds.value": newWounds });
 
         if (game.combat && game.user.isGM) {
           let minorInfections = game.combat.getFlag("wfrp4e", "minorInfections") || []
           minorInfections.push(item.actor.name)
-          game.combat.setFlag("wfrp4e", "minorInfections", null).then(c => game.combat.setFlag("wfrp4e", "minorInfections", minorInfections))
+          await game.combat.setFlag("wfrp4e", "minorInfections", null);
+          await game.combat.setFlag("wfrp4e", "minorInfections", minorInfections);
         }
       }
     }
@@ -93,13 +94,13 @@ export default function () {
     }
   })
 
-  Hooks.on("deleteItem", (item, options, id) => {
+  Hooks.on("deleteItem", async (item, options, id) => {
     if (game.user.id != id)
     return
 
     if (item.actor)
     {
-      item.actor.runEffects("update", {item, context: "delete"}, {async: true})
+      await item.actor.runEffectsAsync("update", {item, context: "delete"});
     }
   })
 

--- a/modules/item/item-wfrp4e.js
+++ b/modules/item/item-wfrp4e.js
@@ -81,17 +81,16 @@ export default class ItemWfrp4e extends Item {
             conditions.push(e)
         })
 
-        immediateEffects.forEach(effect => {
-          game.wfrp4e.utility.applyOneTimeEffect(effect, this.actor)
-          this.effects.delete(effect.id)
-        })
-        conditions.forEach(condition => {
-          if (condition.conditionId != "fear")
-          {
-            this.actor.addCondition(condition.conditionId, condition.conditionValue)
+        for (let effect of immediateEffects) {
+          await game.wfrp4e.utility.applyOneTimeEffect(effect, this.actor);
+          this.effects.delete(effect.id);
+        }
+        for (let condition of conditions) {
+          if (condition.conditionId != "fear") {
+            await this.actor.addCondition(condition.conditionId, condition.conditionValue)
             this.effects.delete(condition.id)
           }
-        })
+        }
       }
 
       if (this.actor.type == "character" && this.type == "spell" && (this.lore.value == "petty" || this.lore.value == game.i18n.localize("WFRP4E.MagicLores.petty"))) {
@@ -1569,7 +1568,8 @@ export default class ItemWfrp4e extends Item {
     else if (existing) {
       existing = duplicate(existing)
       existing.flags.wfrp4e.value += value;
-      return this.updateEmbeddedDocuments("ActiveEffect", [existing])
+      await this.updateEmbeddedDocuments("ActiveEffect", [existing])
+      return;
     }
     else if (!existing) {
       effect.label = game.i18n.localize(effect.label);
@@ -1577,7 +1577,8 @@ export default class ItemWfrp4e extends Item {
         effect.flags.wfrp4e.value = value;
       effect["flags.core.statusId"] = effect.id;
       delete effect.id
-      return this.createEmbeddedDocuments("ActiveEffect", [effect])
+      await this.createEmbeddedDocuments("ActiveEffect", [effect])
+      return;
     }
   }
 
@@ -1592,15 +1593,17 @@ export default class ItemWfrp4e extends Item {
 
     let existing = this.hasCondition(effect.id)
     
-    if (existing && existing.flags.wfrp4e.value == null)
-      return this.deleteEmbeddedDocuments("ActiveEffect", [existing._id])
+    if (existing && existing.flags.wfrp4e.value == null) {
+      await this.deleteEmbeddedDocuments("ActiveEffect", [existing._id])
+      return;
+    }
     else if (existing) {
       await existing.setFlag("wfrp4e", "value", existing.conditionValue - value);
 
       if (existing.flags.wfrp4e.value <= 0)
-        return this.deleteEmbeddedDocuments("ActiveEffect", [existing._id])
+        await this.deleteEmbeddedDocuments("ActiveEffect", [existing._id])
       else
-        return this.updateEmbeddedDocuments("ActiveEffect", [existing])
+        await this.updateEmbeddedDocuments("ActiveEffect", [existing])
     }
   }
 

--- a/modules/item/item-wfrp4e.js
+++ b/modules/item/item-wfrp4e.js
@@ -1742,13 +1742,14 @@ export default class ItemWfrp4e extends Item {
   get damageEffects()
   {
     let ammoEffects = this.ammo?.damageEffects
-    let itemDamageEffects = this.effects.filter(e => e.application == "damage" && !e.disabled).concat(ammoEffects)
-    if (this.system.lore?.effect?.application == "damage")
-    {
+    let itemDamageEffects = this.effects.filter(e => e.application == "damage" && !e.disabled);
+    if (ammoEffects) {
+      itemDamageEffects = itemDamageEffects.concat(ammoEffects)
+    }
+    if (this.system.lore?.effect?.application == "damage") {
       itemDamageEffects.push(this.system.lore.effect)
     }
-    if (this.flags.wfrp4e?.conditionalEffects?.length)
-    {
+    if (this.flags.wfrp4e?.conditionalEffects?.length) {
       itemDamageEffects = itemDamageEffects.concat(this.flags.wfrp4e?.conditionalEffects.map(e => new EffectWfrp4e(e, {parent: this})))
     }
     return itemDamageEffects

--- a/modules/item/item-wfrp4e.js
+++ b/modules/item/item-wfrp4e.js
@@ -187,7 +187,7 @@ export default class ItemWfrp4e extends Item {
   prepareOwnedData() {
 
     try {
-      this.actor.runEffects("prePrepareItem", { item: this })
+      this.actor.runEffectsSync("prePrepareItem", { item: this })
 
       // Call `prepareOwned<Type>` function
       let functionName = `prepareOwned${this.type[0].toUpperCase() + this.type.slice(1, this.type.length)}`
@@ -211,7 +211,7 @@ export default class ItemWfrp4e extends Item {
         this.encumbrance.value = this.encumbrance.value < 0 ? 0 : this.encumbrance.value;
       }
 
-      this.actor.runEffects("prepareItem", { item: this })
+      this.actor.runEffectsSync("prepareItem", { item: this })
     }
     catch (e) {
       game.wfrp4e.utility.log(`Something went wrong when preparing actor item ${this.name}: ${e}`)

--- a/modules/system/aoe.js
+++ b/modules/system/aoe.js
@@ -206,6 +206,7 @@ export default class AbilityTemplate extends MeasuredTemplate {
         newTokenTargets.push(t.id)
     })
     game.user.updateTokenTargets(newTokenTargets)
+    game.user.broadcastActivity({targets: newTokenTargets})
   }
 
 }

--- a/modules/system/combat.js
+++ b/modules/system/combat.js
@@ -16,8 +16,7 @@ export default class CombatHelpers {
 
     static async combatChecks(combat, type) {
         let scripts = CombatHelpers.scripts[type];
-        for (let i = 0; i < scripts.length; i++) {
-           const script = scripts[i];
+        for (let script of scripts) {
            await script(combat);
         }
     }
@@ -84,8 +83,7 @@ export default class CombatHelpers {
 
         let content = ""
 
-        for (let i = 0; i < CombatHelpers.scripts.endCombatScripts.length; i++) {
-            const script = CombatHelpers.scripts.endCombatScripts[i];
+        for (let script of CombatHelpers.scripts.endCombatScripts) {
             const scriptResult = await script(combat);
             if (scriptResult)
                 content += scriptResult + "<br><br>";
@@ -129,7 +127,7 @@ export default class CombatHelpers {
         msg += CombatHelpers.checkSizeFearTerror(combat)
 
         if (msg)
-            ChatMessage.create({ content: msg })
+            await ChatMessage.create({ content: msg })
     }
 
     static checkSizeFearTerror(combat) {
@@ -286,8 +284,7 @@ export default class CombatHelpers {
             }
 
             let conditions = turn.actor.actorEffects.filter(e => e.isCondition)
-            for (let i = 0; i < conditions.length; i++) {
-                const cond = conditions[i];
+            for (let cond of conditions) {
                 // I swear to god whoever thought it was a good idea for these conditions to reduce every *other* round...
                 if (cond.statusId == "deafened" || cond.statusId == "blinded" && Number.isNumeric(cond.flags.wfrp4e.roundReceived)) {
                     if ((combat.round - 1) % 2 == cond.flags.wfrp4e.roundReceived % 2) {
@@ -356,8 +353,7 @@ export default class CombatHelpers {
             await WFRP_Utility.updateGroupAdvantage({players : 0, enemies : 0})
         } 
 
-        for (let i = 0; i < combat.turns.length; i++) {
-            let turn = combat.turns[i];
+        for (let turn of combat.turns) {
             await turn.actor.update({ "system.status.advantage.value": 0 }, {skipGroupAdvantage: true})
             await turn.actor.runEffectsAsync("endCombat", combat)
         }

--- a/modules/system/config-wfrp4e.js
+++ b/modules/system/config-wfrp4e.js
@@ -1102,21 +1102,19 @@ WFRP4E.PrepareSystemItems = function() {
                     "effectTrigger": "oneTime",
                     "effectApplication": "actor",
                     "terrorValue": 1,
+                    "isAsynch": true,
                     "script": `
                         let skillName = game.i18n.localize("NAME.Cool");
-                        args.actor.setupSkill(skillName, {terror: true}).then(setupData =>{
-                        args.actor.basicTest(setupData).then(test => {
-                            let terror = this.effect.flags.wfrp4e.terrorValue;   
-                            args.actor.applyFear(terror, name)
-                            if (test.result.outcome == "failure")
-                            {            
-                                if (test.result.SL < 0)
-                                    terror += Math.abs(test.result.SL)
-                    
-                                args.actor.addCondition("broken", terror)
-                            }
-                            })
-                        })`
+                        let setupData = await args.actor.setupSkill(skillName, {terror: true});
+                        let test = await args.actor.basicTest(setupData);
+                        let terror = this.effect.flags.wfrp4e.terrorValue;  
+                        if (test.result.outcome == "failure") {            
+                            if (test.result.SL < 0)
+                                terror += Math.abs(test.result.SL)
+                            await args.actor.addCondition("broken", terror)
+                        } else {
+                            await args.actor.applyFear(terror, name);
+                        }`
                 }
             }
         }
@@ -1224,17 +1222,17 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
+                    "isAsynch": true,
                     "script": `
                         let tb = this.actor.characteristics.t.bonus
                         let damage = (await new Roll("1d10").roll()).total
                         damage -= tb
                         if (damage <= 0) damage = 1
-                        if (this.actor.status.wounds.value <= damage)
-                        {
-                            this.actor.addCondition("unconscious")
+                        if (this.actor.status.wounds.value <= damage) {
+                            await this.actor.addCondition("unconscious")
                         }
                         this.actor.modifyWounds(-damage)
-                    ui.notifications.notify(game.i18n.format("TookDamage", { damage: damage }))
+                        ui.notifications.notify(game.i18n.format("TookDamage", { damage: damage }))
                     `
                 }
             }
@@ -1288,13 +1286,16 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
+                    "isAsynch": true,
                     "script": `
                         let tb = this.actor.characteristics.t.bonus
                         let damage = (await new Roll("1d10").roll()).total
                         damage -= tb
-                        if (damage <= 0) damage = 1
+                        if (damage <= 0) {
+                            damage = 1
+                        }
                         this.actor.modifyWounds(-damage)
-                    ui.notifications.notify(game.i18n.format("TookDamage", { damage: damage }))
+                        ui.notifications.notify(game.i18n.format("TookDamage", { damage: damage }))
                     `
                 }
             }
@@ -1338,11 +1339,14 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
+                    "isAsynch": true,
                     "script": `
                     let tb = this.actor.characteristics.t.bonus
                     let damage = (await new Roll("1d10").roll()).total
                     damage -= tb
-                    if (damage <= 0) damage = 1
+                    if (damage <= 0) {
+                        damage = 1
+                    }
                     this.actor.modifyWounds(-damage)
                     ui.notifications.notify(game.i18n.format("TookDamage", { damage: damage }))
                 `
@@ -1388,11 +1392,14 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
+                    "isAsynch": true,
                     "script": `
                     let tb = this.actor.characteristics.t.bonus
                     let damage = (await new Roll("1d10").roll()).total
                     damage -= tb
-                    if (damage <= 0) damage = 1
+                    if (damage <= 0) {
+                        damage = 1
+                    }
                     this.actor.modifyWounds(-damage)
                     ui.notifications.notify(game.i18n.format("TookDamage", { damage: damage }))
                 `
@@ -1897,6 +1904,20 @@ WFRP4E.effectTriggers = {
     "endRound" : "End Round",
     "endCombat" : "End Combat"
 }
+
+WFRP4E.syncEffectTriggers = [
+    "prePrepareData",
+    "prePrepareItems",
+    "prepareData",
+    "preWoundCalc",
+    "woundCalc",
+    "calculateSize",
+    "preAPCalc",
+    "APCalc",
+    "prePrepareItem",
+    "prepareItem",
+    "getInitiativeFormula"
+];
 
 WFRP4E.effectPlaceholder = {
 

--- a/modules/system/config-wfrp4e.js
+++ b/modules/system/config-wfrp4e.js
@@ -1757,7 +1757,7 @@ WFRP4E.conditionScripts = {
         let msg = `<h2>${game.i18n.localize("WFRP4E.ConditionName.Ablaze")}</h2><b>${game.i18n.localize("Formula")}</b>: @FORMULA<br><b>${game.i18n.localize("Roll")}</b>: @ROLLTERMS` 
         
         let args = {msg, formula}
-        actor.runEffects("preApplyCondition", {effect, data : args});
+        await actor.runEffectsAsync("preApplyCondition", {effect, data : args});
         formula = args.formula;
         msg = args.msg;
         let roll = await new Roll(`${formula}`).roll({async: true});
@@ -1770,7 +1770,7 @@ WFRP4E.conditionScripts = {
         msg += damageMsg.join("");
         let messageData = game.wfrp4e.utility.chatDataSetup(msg);
         messageData.speaker = {alias: actor.prototypeToken.name}
-        actor.runEffects("applyCondition", {effect, data : {messageData}})
+        await actor.runEffectsAsync("applyCondition", {effect, data : {messageData}})
         return messageData
     },
     "poisoned" : async function (actor) {
@@ -1779,13 +1779,13 @@ WFRP4E.conditionScripts = {
 
         let damage = effect.conditionValue;
         let args = {msg, damage};
-        actor.runEffects("preApplyCondition", {effect, data : args})
+        await actor.runEffectsAsync("preApplyCondition", {effect, data : args})
         msg = args.msg;
         damage = args.damage;
         msg += await actor.applyBasicDamage(damage, {damageType : game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL, suppressMsg : true})
         let messageData = game.wfrp4e.utility.chatDataSetup(msg);
         messageData.speaker = {alias: actor.prototypeToken.name}
-        actor.runEffects("applyCondition", {effect, data : {messageData}})
+        await actor.runEffectsAsync("applyCondition", {effect, data : {messageData}})
         return messageData
     },
     "bleeding" : async function(actor) {
@@ -1794,10 +1794,9 @@ WFRP4E.conditionScripts = {
         let bleedingRoll;
         let msg = `<h2>${game.i18n.localize("WFRP4E.ConditionName.Bleeding")}</h2>`
 
-        actor.runEffects("preApplyCondition", {effect, data : {msg}})
         let damage = effect.conditionValue;
         let args = {msg, damage};
-        actor.runEffects("preApplyCondition", {effect, data : args})
+        await actor.runEffectsAsync("preApplyCondition", {effect, data : args})
         msg = args.msg;
         damage = args.damage;
         msg += await actor.applyBasicDamage(damage, {damageType : game.wfrp4e.config.DAMAGE_TYPE.IGNORE_ALL, minimumOne : false, suppressMsg : true})
@@ -1812,25 +1811,22 @@ WFRP4E.conditionScripts = {
         {
             bleedingAmt = value;
             bleedingRoll = (await new Roll("1d100").roll()).total;
-            if (bleedingRoll <= bleedingAmt * 10)
-            {
+            if (bleedingRoll <= bleedingAmt * 10) {
                 msg += `<br>${game.i18n.format("BleedFail", {name: actor.prototypeToken.name} )} (${game.i18n.localize("Rolled")} ${bleedingRoll})`
-                actor.addCondition("dead")
+                await actor.addCondition("dead")
             }
-            else if (bleedingRoll % 11 == 0)
-            {
+            else if (bleedingRoll % 11 == 0) {
                 msg += `<br>${game.i18n.format("BleedCrit", { name: actor.prototypeToken.name } )} (${game.i18n.localize("Rolled")} ${bleedingRoll})`
-                actor.removeCondition("bleeding")
+                await actor.removeCondition("bleeding")
             }
-            else 
-            {
+            else {
                 msg += `<br>${game.i18n.localize("BleedRoll")}: ${bleedingRoll}`
             }
         }
 
         let messageData = game.wfrp4e.utility.chatDataSetup(msg);
         messageData.speaker = {alias: actor.prototypeToken.name}
-        actor.runEffects("applyCondition", {effect, data : {messageData, bleedingRoll}})
+        await actor.runEffectsAsync("applyCondition", {effect, data : {messageData, bleedingRoll}})
         return messageData
     }
 }
@@ -1905,26 +1901,26 @@ WFRP4E.effectTriggers = {
 WFRP4E.effectPlaceholder = {
 
     "invoke" : 
-    `This effect is only applied when the Invoke button is pressed.
+    `This effect is only applied when the Invoke button is pressed. Can be async.
     args:
 
     none`,
     "oneTime" : 
-    `This effect happens once, immediately when applied.
+    `This effect happens once, immediately when applied. Can be async.
     args:
 
     actor : actor who owns the effect
     `,
 
     "addItems" : 
-    `Like Immediate effects, this happens once, but the effect will remain. This lets the effect also delete the added items when the effect is deleted.
-    args:
+    `Like Immediate effects, this happens once, but the effect will remain. This lets the effect also delete the added items when the effect is deleted. Can be async.
+    args: 
 
     actor : actor who owns the effect
     `,
 
     "prefillDialog" : 
-    `This effect is applied before rendering the roll dialog, and is meant to change the values prefilled in the bonus section
+    `This effect is applied before rendering the roll dialog, and is meant to change the values prefilled in the bonus section. Can be async.
     args:
 
     prefillModifiers : {modifier, difficulty, slBonus, successBonus}
@@ -1936,13 +1932,13 @@ WFRP4E.effectPlaceholder = {
     if (args.type == "skill" && args.item.name == "Athletics") args.prefillModifiers.modifier += 10`,
 
     "prePrepareData" : 
-    `This effect is applied before any actor data is calculated.
+    `This effect is applied before any actor data is calculated. Cannot be async.
     args:
 
     actor : actor who owns the effect
     `,
     "update" : 
-    `This effect runs when an actor or an embedded document is changed
+    `This effect runs when an actor or an embedded document is changed. Can be async.
     args:
 
     item: if an item is modified, it is provided as an argument
@@ -1950,20 +1946,20 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "prePrepareData" : 
-    `This effect is applied before any actor data is calculated.
+    `This effect is applied before any actor data is calculated. Cannot be async.
     args:
 
     actor : actor who owns the effect
     `,
 
     "prePrepareItems" : 
-    `This effect is applied before items are sorted and calculated
+    `This effect is applied before items are sorted and calculated. Cannot be async.
 
     actor : actor who owns the effect
     `,
 
     "prepareData" : 
-    `This effect is applied after actor data is calculated and processed.
+    `This effect is applied after actor data is calculated and processed. Cannot be async.
 
     args:
 
@@ -1971,7 +1967,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preWoundCalc" : 
-    `This effect is applied right before wound calculation, ideal for swapping out characteristics or adding multipiliers
+    `This effect is applied right before wound calculation, ideal for swapping out characteristics or adding multipiliers. Cannot be async.
 
     actor : actor who owns the effect
     sb : Strength Bonus
@@ -1987,7 +1983,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "woundCalc" : 
-    `This effect happens after wound calculation, ideal for multiplying the result.
+    `This effect happens after wound calculation, ideal for multiplying the result. Cannot be async.
 
     args:
 
@@ -1998,7 +1994,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "calculateSize" : 
-    `This effect is applied after size calculation, where it can be overridden.
+    `This effect is applied after size calculation, where it can be overridden. Cannot be async.
 
     args:
 
@@ -2007,7 +2003,7 @@ WFRP4E.effectPlaceholder = {
     e.g. for Small: "args.size = 'sml'"
     `,
 
-    "preAPCalc" : `This effect is applied before AP is calculated.
+    "preAPCalc" : `This effect is applied before AP is calculated. Cannot be async.
 
     args:
 
@@ -2015,7 +2011,7 @@ WFRP4E.effectPlaceholder = {
 
     e.g. args.AP.head.value += 1
     `,
-    "APCalc" : `This effect is applied after AP is calculated.
+    "APCalc" : `This effect is applied after AP is calculated. Cannot be async.
 
     args:
 
@@ -2025,7 +2021,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preApplyDamage" : 
-    `This effect happens before applying damage in an opposed test
+    `This effect happens before applying damage in an opposed test. Can be async.
 
     args:
 
@@ -2040,7 +2036,7 @@ WFRP4E.effectPlaceholder = {
     AP : Defender's AP object
     `,
     "applyDamage" : 
-    `This effect happens after damage in an opposed test is calculated, but before actor data is updated.
+    `This effect happens after damage in an opposed test is calculated, but before actor data is updated. Can be async.
 
     args:
 
@@ -2056,7 +2052,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preTakeDamage" : 
-    `This effect happens before taking damage in an opposed test
+    `This effect happens before taking damage in an opposed test. Can be async.
 
     args:
     actor : actor who is taking damage
@@ -2071,7 +2067,7 @@ WFRP4E.effectPlaceholder = {
     `,
     
     "takeDamage" : 
-    `This effect happens after damage in an opposed test is calculated, but before actor data is updated.
+    `This effect happens after damage in an opposed test is calculated, but before actor data is updated. Can be async.
 
     args:
 
@@ -2087,7 +2083,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preApplyCondition" :  
-    `This effect happens before effects of a condition are applied.
+    `This effect happens before effects of a condition are applied. Can be async.
 
     args:
 
@@ -2099,7 +2095,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "applyCondition" :  
-    `This effect happens after effects of a condition are applied.
+    `This effect happens after effects of a condition are applied. Can be async.
 
     args:
 
@@ -2110,21 +2106,21 @@ WFRP4E.effectPlaceholder = {
     }
     `,
     "prePrepareItem" : 
-    `This effect is applied before an item is processed with actor data.
+    `This effect is applied before an item is processed with actor data. Cannot be async.
 
     args:
 
     item : item being processed
     `,
     "prepareItem" : 
-    `This effect is applied after an item is processed with actor data.
+    `This effect is applied after an item is processed with actor data. Cannot be async.
 
     args:
 
     item : item processed
     `,
     "preRollTest": 
-    `This effect is applied before a test is calculated.
+    `This effect is applied before a test is calculated. Can be async.
 
     args:
 
@@ -2132,7 +2128,7 @@ WFRP4E.effectPlaceholder = {
     cardOptions: Data for the card display, title, template, etc
     `,
     "preRollWeaponTest" :  
-    `This effect is applied before a weapon test is calculated.
+    `This effect is applied before a weapon test is calculated. Can be async.
 
     args:
 
@@ -2141,7 +2137,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preRollCastTest" :  
-    `This effect is applied before a casting test is calculated.
+    `This effect is applied before a casting test is calculated. Can be async.
 
     args:
 
@@ -2150,7 +2146,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preChannellingTest" :  
-    `This effect is applied before a channelling test is calculated.
+    `This effect is applied before a channelling test is calculated. Can be async.
 
     args:
 
@@ -2159,7 +2155,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preRollPrayerTest" :  
-    `This effect is applied before a prayer test is calculated.
+    `This effect is applied before a prayer test is calculated. Can be async.
 
     args:
 
@@ -2168,7 +2164,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preRollTraitTest" :  
-    `This effect is applied before a trait test is calculated.
+    `This effect is applied before a trait test is calculated. Can be async.
 
     args:
 
@@ -2177,7 +2173,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "rollTest" : 
-    `This effect is applied after a test is calculated.
+    `This effect is applied after a test is calculated. Can be async.
 
     args:
 
@@ -2185,7 +2181,7 @@ WFRP4E.effectPlaceholder = {
     cardOptions: Data for the card display, title, template, etc
     `,
     "rollIncomeTest" : 
-    `This effect is applied after an income test is calculated.
+    `This effect is applied after an income test is calculated. Can be async.
 
     args:
 
@@ -2194,7 +2190,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "rollWeaponTest" : 
-    `This effect is applied after a weapon test is calculated.
+    `This effect is applied after a weapon test is calculated. Can be async.
 
     args:
 
@@ -2203,7 +2199,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "rollCastTest" : 
-    `This effect is applied after a casting test is calculated.
+    `This effect is applied after a casting test is calculated. Can be async.
 
     args:
 
@@ -2212,7 +2208,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "rollChannellingTest" : 
-    `This effect is applied after a channelling test is calculated.
+    `This effect is applied after a channelling test is calculated. Can be async.
 
     args:
 
@@ -2221,7 +2217,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "rollPrayerTest" : 
-    `This effect is applied after a prayer test is calculated.
+    `This effect is applied after a prayer test is calculated. Can be async.
 
     args:
 
@@ -2230,7 +2226,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "rollTraitTest" : 
-    `This effect is applied after a trait test is calculated.
+    `This effect is applied after a trait test is calculated. Can be async.
 
     args:
 
@@ -2239,7 +2235,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "preOpposedAttacker" : 
-    `This effect is applied before an opposed test result begins calculation, as the attacker.
+    `This effect is applied before an opposed test result begins calculation, as the attacker. Can be async.
 
     args:
 
@@ -2248,7 +2244,7 @@ WFRP4E.effectPlaceholder = {
     opposedTest: opposedTest object, before calculation
     `,
     "preOpposedDefender" : 
-    `This effect is applied before an opposed test result begins calculation, as the defender.
+    `This effect is applied before an opposed test result begins calculation, as the defender. Can be async.
 
     args:
 
@@ -2258,7 +2254,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "opposedAttacker" : 
-    `This effect is applied after an opposed test result begins calculation, as the attacker.
+    `This effect is applied after an opposed test result begins calculation, as the attacker. Can be async.
 
     args:
 
@@ -2268,7 +2264,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "opposedDefender" : 
-    `This effect is applied before an opposed test result begins calculation, as the defender.
+    `This effect is applied before an opposed test result begins calculation, as the defender. Can be async.
 
     args:
 
@@ -2278,7 +2274,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "calculateOpposedDamage" : 
-    `This effect is applied during an opposed test damage calculation. This effect runs on the attacking actor
+    `This effect is applied during an opposed test damage calculation. This effect runs on the attacking actor. Can be async.
 
     args:
 
@@ -2291,7 +2287,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "getInitiativeFormula" : 
-    `This effect runs when determining actor's initiative
+    `This effect runs when determining actor's initiative. Cannot be async.
 
     args:
 
@@ -2299,7 +2295,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "targetPrefillDialog" : 
-    `This effect is applied to another actor whenever they target this actor, and is meant to change the values prefilled in the bonus section
+    `This effect is applied to another actor whenever they target this actor, and is meant to change the values prefilled in the bonus section. Can be async.
     args:
 
     prefillModifiers : {modifier, difficulty, slBonus, successBonus}
@@ -2311,7 +2307,7 @@ WFRP4E.effectPlaceholder = {
     if (args.type == "skill" && args.item.name == "Athletics") args.prefillModifiers.modifier += 10`,
 
     "endTurn" : 
-    `This effect runs at the end of an actor's turn
+    `This effect runs at the end of an actor's turn. Can be async.
 
     args:
 
@@ -2319,7 +2315,7 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "startTurn" : 
-    `This effect runs at the start of an actor's turn
+    `This effect runs at the start of an actor's turn. Can be async.
 
     args:
 
@@ -2327,14 +2323,14 @@ WFRP4E.effectPlaceholder = {
     `,
 
     "endRound" :  
-    `This effect runs at the end of a round
+    `This effect runs at the end of a round. Can be async.
 
     args:
 
     combat: current combat
     `,
     "endCombat" :  
-    `This effect runs when combat has ended
+    `This effect runs when combat has ended. Can be async.
 
     args:
 

--- a/modules/system/config-wfrp4e.js
+++ b/modules/system/config-wfrp4e.js
@@ -1102,7 +1102,7 @@ WFRP4E.PrepareSystemItems = function() {
                     "effectTrigger": "oneTime",
                     "effectApplication": "actor",
                     "terrorValue": 1,
-                    "isAsynch": true,
+                    "isAsync": true,
                     "script": `
                         let skillName = game.i18n.localize("NAME.Cool");
                         let setupData = await args.actor.setupSkill(skillName, {terror: true});
@@ -1222,7 +1222,7 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
-                    "isAsynch": true,
+                    "isAsync": true,
                     "script": `
                         let tb = this.actor.characteristics.t.bonus
                         let damage = (await new Roll("1d10").roll()).total
@@ -1286,7 +1286,7 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
-                    "isAsynch": true,
+                    "isAsync": true,
                     "script": `
                         let tb = this.actor.characteristics.t.bonus
                         let damage = (await new Roll("1d10").roll()).total
@@ -1339,7 +1339,7 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
-                    "isAsynch": true,
+                    "isAsync": true,
                     "script": `
                     let tb = this.actor.characteristics.t.bonus
                     let damage = (await new Roll("1d10").roll()).total
@@ -1392,7 +1392,7 @@ WFRP4E.PrepareSystemItems = function() {
                 wfrp4e: {
                     "effectTrigger": "invoke",
                     "effectApplication": "actor",
-                    "isAsynch": true,
+                    "isAsync": true,
                     "script": `
                     let tb = this.actor.characteristics.t.bonus
                     let damage = (await new Roll("1d10").roll()).total

--- a/modules/system/effect-wfrp4e.js
+++ b/modules/system/effect-wfrp4e.js
@@ -127,14 +127,14 @@ export default class EffectWfrp4e extends ActiveEffect {
   }
 
   get isAsync () {
-    return getProperty(this, "flags.wfrp4e.isAsync") && (WFRP_Utility.syncEffectTriggers.indexOf(this.trigger) === -1)
+    return getProperty(this, "flags.wfrp4e.isAsync") && (game.wfrp4e.config.syncEffectTriggers.indexOf(this.trigger) === -1)
   }
 
-  reduceItemQuantity() {
+  async reduceItemQuantity() {
     if (this.reduceQuantity && this.item)
     {
       if (this.item.quantity.value > 0)
-        this.item.update({"system.quantity.value" : this.item.quantity.value - 1})
+        await this.item.update({"system.quantity.value" : this.item.quantity.value - 1})
       else 
         throw ui.notifications.error(game.i18n.localize("EFFECT.QuantityError"))
     }  
@@ -149,5 +149,4 @@ export default class EffectWfrp4e extends ActiveEffect {
   get specifier() {
     return this.label.substring(this.label.indexOf("(") + 1, this.label.indexOf(")"))
   }
-
 }

--- a/modules/system/effect-wfrp4e.js
+++ b/modules/system/effect-wfrp4e.js
@@ -126,6 +126,10 @@ export default class EffectWfrp4e extends ActiveEffect {
     return this.parent?.type == "trapping" && getProperty(this, "flags.wfrp4e.reduceQuantity")
   }
 
+  get isAsync () {
+    return getProperty(this, "flags.wfrp4e.isAsync") && (WFRP_Utility.syncEffectTriggers.indexOf(this.trigger) === -1)
+  }
+
   reduceItemQuantity() {
     if (this.reduceQuantity && this.item)
     {

--- a/modules/system/opposed-test.js
+++ b/modules/system/opposed-test.js
@@ -134,8 +134,8 @@ export default class OpposedTest {
       let defender = this.defenderTest.actor
 
 
-      attacker.runEffects("preOpposedAttacker", { attackerTest, defenderTest, opposedTest: this })
-      defender.runEffects("preOpposedDefender", { attackerTest, defenderTest, opposedTest: this })
+      await attacker.runEffectsAsync("preOpposedAttacker", { attackerTest, defenderTest, opposedTest: this })
+      await defender.runEffectsAsync("preOpposedDefender", { attackerTest, defenderTest, opposedTest: this })
 
 
       opposeResult.modifiers = this.checkPostModifiers(attackerTest, defenderTest);
@@ -158,7 +158,7 @@ export default class OpposedTest {
         await defenderTest.renderRollCard();
       }
       else if (defenderTest.context.unopposed)
-        defenderTest.roll();
+        await defenderTest.roll();
 
       opposeResult.other = opposeResult.other.concat(opposeResult.modifiers.message);
 
@@ -174,7 +174,7 @@ export default class OpposedTest {
 
         // If Damage is a numerical value
         if (Number.isNumeric(attackerTest.damage)) {
-          let damage = this.calculateOpposedDamage();
+          let damage = await this.calculateOpposedDamage();
           opposeResult.damage = {
             description: `<b>${game.i18n.localize("Damage")}</b>: ${damage}`,
             value: damage
@@ -257,7 +257,7 @@ export default class OpposedTest {
           this.attackerTest = game.wfrp4e.rolls.TestWFRP.recreate(temp)
           this.data.attackerTestData = this.attackerTest.data
           this.data.defenderTestData = this.defenderTest.data
-          let damage = this.calculateOpposedDamage();
+          let damage = await this.calculateOpposedDamage();
           opposeResult.damage = {
             description: `<b>${game.i18n.localize("Damage")} (${riposte ? game.i18n.localize("NAME.Riposte") : game.i18n.localize("NAME.Champion")})</b>: ${damage}`,
             value: damage
@@ -274,15 +274,14 @@ export default class OpposedTest {
         }
       }
 
-      attacker.runEffects("opposedAttacker", { opposedTest: this, attackerTest, defenderTest })
+      await attacker.runEffectsAsync("opposedAttacker", { opposedTest: this, attackerTest, defenderTest })
       if (defender)
-        defender.runEffects("opposedDefender", { opposedTest: this, attackerTest, defenderTest })
+        await defender.runEffectsAsync("opposedDefender", { opposedTest: this, attackerTest, defenderTest })
 
       Hooks.call("wfrp4e:opposedTestResult", this, attackerTest, defenderTest)
       WFRP_Audio.PlayContextAudio(soundContext)
 
       return opposeResult
-
     }
     catch (err) {
       ui.notifications.error(`${game.i18n.localize("ErrorOpposed")}: ` + err)
@@ -291,7 +290,7 @@ export default class OpposedTest {
   }
 
 
-  calculateOpposedDamage() {
+  async calculateOpposedDamage() {
     // Calculate size damage multiplier 
     let damageMultiplier = 1;
     let sizeDiff
@@ -349,7 +348,7 @@ export default class OpposedTest {
     //@/HOUSE
 
     let effectArgs = { damage, damageMultiplier, sizeDiff, opposedTest: this, addDamaging : false, addImpact : false }
-    this.attackerTest.actor.runEffects("calculateOpposedDamage", effectArgs);
+    await this.attackerTest.actor.runEffectsAsync("calculateOpposedDamage", effectArgs);
     ({ damage, damageMultiplier, sizeDiff } = effectArgs)
 
     let addDamaging = effectArgs.addDamaging || false;

--- a/modules/system/opposed-wfrp4e.js
+++ b/modules/system/opposed-wfrp4e.js
@@ -81,24 +81,24 @@ export default class OpposedWFRP {
   async startOppose(targetToken) {
     this.data.targetSpeakerData = targetToken.actor.speakerData(targetToken)
     await this.renderOpposedStart();
-    this._addOpposeFlagsToDefender(targetToken);
+    await this._addOpposeFlagsToDefender(targetToken);
     return this.message.id
   }
 
-  setAttacker(message) {
+  async setAttacker(message) {
     this.data.attackerMessageId = typeof message == "string" ? message : message.id;
     this.data.options = {
       whisper: message.whisper,
       blind: message.blind
     }
     if (this.message)
-      return this.updateMessageFlags();
+      await this.updateMessageFlags();
   }
 
-  setDefender(message) {
+  async setDefender(message) {
     this.data.defenderMessageId = typeof message == "string" ? message : message.id
     if (this.message)
-      return this.updateMessageFlags();
+      await this.updateMessageFlags();
   }
 
   async computeOpposeResult() {
@@ -109,24 +109,23 @@ export default class OpposedWFRP {
 
     await this.opposedTest.evaluate();
     this.formatOpposedResult();
-    this.renderOpposedResult()
-    this.colorWinnerAndLoser()
+    await this.renderOpposedResult()
+    await this.colorWinnerAndLoser()
   }
 
-  renderOpposedStart() {
-    return new Promise(async resolve => {
-      let attacker = game.canvas.tokens.get(this.attackerTest.context.cardOptions.speaker.token)?.document ?? this.attacker.prototypeToken;
-      let defender
+  async renderOpposedStart() {
+    let attacker = game.canvas.tokens.get(this.attackerTest.context.cardOptions.speaker.token)?.document ?? this.attacker.prototypeToken;
+    let defender
 
-      // Support opposed start messages when defender is not set yet - allows for manual opposed to use this message
-      if (this.target)
-        defender = this.target
-      else if (this.defenderTest)
-        defender = WFRP_Utility.getToken(this.defenderTest.context.speaker) || this.defender.prototypeToken;
+    // Support opposed start messages when defender is not set yet - allows for manual opposed to use this message
+    if (this.target)
+      defender = this.target
+    else if (this.defenderTest)
+      defender = WFRP_Utility.getToken(this.defenderTest.context.speaker) || this.defender.prototypeToken;
 
-      let defenderImg = defender ? `<a class = "defender"><img src="${defender.texture.src}" width="50" height="50"/></a>` : `<a class = "defender"><img width="50" height="50"/></a>`
+    let defenderImg = defender ? `<a class = "defender"><img src="${defender.texture.src}" width="50" height="50"/></a>` : `<a class = "defender"><img width="50" height="50"/></a>`
 
-      let content =
+    let content =
         `<div class ="opposed-message">
             ${game.i18n.format("ROLL.Targeting", {attacker: ((attacker.hidden) ? "???" : attacker.name), defender: defender ? defender.name : "???"})}
           </div>
@@ -136,49 +135,40 @@ export default class OpposedWFRP {
           </div>
           <div class="unopposed-button" data-target="true" title="${game.i18n.localize("Unopposed")}"><a><i class="fas fa-arrow-down"></i></a></div>`
 
-
-
-      // Ranged weapon opposed tests automatically lose no matter what if the test itself fails
-      if (this.attackerTest.item && this.attackerTest.item.attackType == "ranged" && this.attackerTest.result.outcome == "failure") {
-        ChatMessage.create({ speaker: this.attackerMessage.speaker, content: game.i18n.localize("OPPOSED.FailedRanged") })
-        //await test.updateMessageFlags({ "context.opposed": false });
-        return;
-      }
-      let chatData = {
+    // Ranged weapon opposed tests automatically lose no matter what if the test itself fails
+    if (this.attackerTest.item && this.attackerTest.item.attackType == "ranged" && this.attackerTest.result.outcome == "failure") {
+      await ChatMessage.create({ speaker: this.attackerMessage.speaker, content: game.i18n.localize("OPPOSED.FailedRanged") })
+      return;
+    }
+    let chatData = {
         user: game.user.id,
         content: content,
         speaker: { alias: game.i18n.localize("CHAT.OpposedTest") },
         whisper: this.options.whisper,
         blind: this.options.blind,
         "flags.wfrp4e.opposeData": this.data
-      }
+    }
 
-      if (this.message) {
+    if (this.message) {
         await this.message.update(chatData);
-        resolve(this.data.messageId);
-      }
-      else {
+        return this.data.messageId;
+    }
+    else {
         // Create the Opposed starting message
-        return ChatMessage.create(chatData).then(async msg => {
-          // Must wait until message and ID is created before proceeding with opposed process
-          this.data.messageId = msg.id;
-          await this.updateMessageFlags();
-          resolve(msg.id);
-        })
-      }
-    })
+        let msg = await ChatMessage.create(chatData);
+        this.data.messageId = msg.id;
+        await this.updateMessageFlags();
+        return msg.id;
+    }
   }
 
-  updateMessageFlags() {
+  async updateMessageFlags() {
     let updateData = { "flags.wfrp4e.opposeData": this.data }
-    if (this.message && game.user.isGM)
-      return this.message.update(updateData)
-
-    else if (this.message)
-    {
-      this.message.flags.wfrp4e.opposeData = this.data // hopefully temporary solution. Other processes likely need flag data to be present immediately, and the inner socket function cannot be awaited, so set data locally
-      game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: this.message.id, updateData } })
-
+    if (this.message && game.user.isGM) {
+      await this.message.update(updateData)
+    }
+    else if (this.message) {
+      await WFRP_Utility.awaitSocket(game.user, "updateMsg", { id: this.message.id, updateData }, "Updating message flags");
     }
   }
 
@@ -198,11 +188,9 @@ export default class OpposedWFRP {
       whisper: options.whisper,
       blind: options.blind,
     }
-    return ChatMessage.create(chatOptions).then(msg => {
-      this.data.resultMessageId = msg.id;
-      this.updateMessageFlags();
-    })
-
+    let msg = await ChatMessage.create(chatOptions);
+    this.data.resultMessageId = msg.id;
+    await this.updateMessageFlags();
   }
 
   formatOpposedResult() {
@@ -233,7 +221,7 @@ export default class OpposedWFRP {
     return opposeResult;
   }
 
-  colorWinnerAndLoser() 
+  async colorWinnerAndLoser() 
   {
     try {
       let winner = this.opposedTest.opposeResult.winner
@@ -247,34 +235,28 @@ export default class OpposedWFRP {
       content = content.replace(loser, `${loser} loser`)
 
       if (!game.user.isGM)
-        return game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: this.message.id, updateData: {content} } })
+        await WFRP_Utility.awaitSocket(game.user, "updateMsg", { id: this.message.id, updateData: {content} }, "Updating winner/looser color");
       else
-        return this.message.update({content})
+        await this.message.update({content});
     }
-    catch(e)
-    {
+    catch(e) {
       console.error(`Error color coding winner and loser: ${e}`)
     }
   }
 
 
-  _addOpposeFlagsToDefender(target) {
+  async _addOpposeFlagsToDefender(target) {
     if (!game.user.isGM) {
-      game.socket.emit("system.wfrp4e", {
-        type: "target",
-        payload: {
-          target: target.id,
-          scene: canvas.scene.id,
-          opposeFlag: { opposeMessageId: this.data.messageId }
-        }
-      })
+      const payload = {
+        target: target.id,
+        scene: canvas.scene.id,
+        opposeFlag: { opposeMessageId: this.data.messageId }
+      }
+      await WFRP_Utility.awaitSocket(game.user, "target", payload, "setting oppose flag");
     }
     else {
       // Add oppose data flag to the target
-      target.actor.update(
-        {
-          "flags.oppose": { opposeMessageId: this.data.messageId }
-        })
+      await target.actor.update({ "flags.oppose": { opposeMessageId: this.data.messageId } });
     }
   }
 
@@ -291,32 +273,28 @@ export default class OpposedWFRP {
 
     // Opposition already exists - click was defender
     if (game.wfrp4e.oppose) {
-      game.wfrp4e.oppose.setDefender(message);
+      await game.wfrp4e.oppose.setDefender(message);
       await game.wfrp4e.oppose.renderOpposedStart() // Rerender opposed start with new message
-      game.wfrp4e.oppose.computeOpposeResult();
+      await game.wfrp4e.oppose.computeOpposeResult();
       delete game.wfrp4e.oppose;
     }
     // No opposition - click was attacker
     else {
       game.wfrp4e.oppose = new OpposedWFRP()
-      game.wfrp4e.oppose.setAttacker(message);
-      game.wfrp4e.oppose.renderOpposedStart()
+      await game.wfrp4e.oppose.setAttacker(message);
+      await game.wfrp4e.oppose.renderOpposedStart()
     }
   }
 
 
-  resolveUnopposed() {
+  async resolveUnopposed() {
     this.data.unopposed = true;
-    this.computeOpposeResult();
-    this.defender.clearOpposed();
-  }
-
-  _updateOpposedMessage(damageConfirmation) {
-    return OpposedWFRP.updateOpposedMessage(damageConfirmation, this.data.resultMessageId)
+    await this.computeOpposeResult();
+    await this.defender.clearOpposed();
   }
 
   // Update starting message with result
-  static updateOpposedMessage(damageConfirmation, messageId) {
+  static async updateOpposedMessage(damageConfirmation, messageId) {
     let resultMessage = game.messages.get(messageId)
     let rollMode = resultMessage.rollMode;
 
@@ -327,9 +305,9 @@ export default class OpposedWFRP {
       content: $(resultMessage.content).append(`<div>${damageConfirmation}</div>`).html()
     }
 
-    if (!game.user.isGM)
-      return game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: messageId, updateData: newCard } })
+    if (!game.user.isGM)  
+      await WFRP_Utility.awaitSocket(game.user, "updateMsg", { id: messageId, updateData: newCard }, "updating opposed damage");
     else
-      return resultMessage.update(newCard)
+      await resultMessage.update(newCard)
   }
 }

--- a/modules/system/overrides.js
+++ b/modules/system/overrides.js
@@ -74,7 +74,7 @@ export default function () {
 
 
     let args = { initiative: initiativeFormula }
-    actor.runEffects("getInitiativeFormula", args)
+    actor.runEffectsSync("getInitiativeFormula", args)
 
     return args.initiative;
   };

--- a/modules/system/overrides.js
+++ b/modules/system/overrides.js
@@ -174,9 +174,9 @@ export default function () {
   Token.prototype.incrementCondition = async function (effect, { active, overlay = false } = {}) {
     const existing = this.actor.actorEffects.find(e => e.getFlag("core", "statusId") === effect.id);
     if (!existing || Number.isNumeric(getProperty(existing, "flags.wfrp4e.value")))
-      this.actor.addCondition(effect.id)
+      await this.actor.addCondition(effect.id)
     else if (existing) // Not numeric, toggle if existing
-      this.actor.removeCondition(effect.id)
+      await this.actor.removeCondition(effect.id)
 
     // Update the Token HUD
     if (this.hasActiveHUD) canvas.tokens.hud.refreshStatusIcons();

--- a/modules/system/rolls/attack-test.js
+++ b/modules/system/rolls/attack-test.js
@@ -49,7 +49,7 @@ export default class AttackTest extends TestWFRP {
     }
   }
 
-  calculateDamage(base)
+  async calculateDamage(base)
   {
     this.result.additionalDamage = this.preData.additionalDamage || 0
 

--- a/modules/system/rolls/cast-test.js
+++ b/modules/system/rolls/cast-test.js
@@ -45,9 +45,9 @@ export default class CastTest extends TestWFRP {
     super.computeTargetNumber();
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollCastTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffectsAsync("preRollCastTest", { test: this, cardOptions: this.context.cardOptions })
     //@HOUSE
     if (this.preData.unofficialGrimoire && this.preData.unofficialGrimoire.ingredientMode == 'power' && this.hasIngredient) { 
       game.wfrp4e.utility.logHomebrew("unofficialgrimoire");
@@ -56,9 +56,9 @@ export default class CastTest extends TestWFRP {
     //@HOUSE
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollCastTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffectsAsync("rollCastTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollCastTest", this, this.context.cardOptions)
   }
 
@@ -327,19 +327,19 @@ export default class CastTest extends TestWFRP {
   }
 
 
-  postTest() {
+  async postTest() {
     //@/HOUSE
     if (this.preData.unofficialGrimoire) {
       game.wfrp4e.utility.logHomebrew("unofficialgrimoire");
       if (this.preData.unofficialGrimoire.ingredientMode != 'none' && this.hasIngredient && this.item.ingredient.quantity.value > 0 && !this.context.edited && !this.context.reroll) {
-        this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
-        ChatMessage.create({ speaker: this.context.speaker, content: game.i18n.localize("ConsumedIngredient") })
+        await this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
+        await ChatMessage.create({ speaker: this.context.speaker, content: game.i18n.localize("ConsumedIngredient") })
       }
     //@/HOUSE
     } else {
       // Find ingredient being used, if any
       if (this.hasIngredient && this.item.ingredient.quantity.value > 0 && !this.context.edited && !this.context.reroll)
-        this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
+        await this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
     }
 
     // Set initial extra overcasting options to SL if checked
@@ -371,11 +371,11 @@ export default class CastTest extends TestWFRP {
         {
           items = this.actor.items.filter(s => s.type == "spell" && s.system.lore.value == this.spell.system.lore.value).map(i => i.toObject())
           items.forEach(i => i.system.cn.SL = 0)
-          this.actor.updateEmbeddedDocuments("Item", items);
+          await this.actor.updateEmbeddedDocuments("Item", items);
         }
         else 
         {
-          this.item.update({ "system.cn.SL": 0 })
+          await this.item.update({ "system.cn.SL": 0 })
         }
       }
 

--- a/modules/system/rolls/channel-test.js
+++ b/modules/system/rolls/channel-test.js
@@ -45,14 +45,14 @@ export default class ChannelTest extends TestWFRP {
       
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preChannellingTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffectsAsync("preChannellingTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollChannellingTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffectsAsync("rollChannellingTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollChannelTest", this, this.context.cardOptions)
   }
 
@@ -149,16 +149,16 @@ export default class ChannelTest extends TestWFRP {
     }
   }
 
-  postTest() {
+  async postTest() {
     //@/HOUSE
 
     
       if (this.preData.unofficialGrimoire) {
         game.wfrp4e.utility.logHomebrew("unofficialgrimoire");
         if (this.preData.unofficialGrimoire.ingredientMode != 'none' && this.hasIngredient && this.item.ingredient.quantity.value > 0 && !this.context.edited && !this.context.reroll) {
-          this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
+          await this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
           this.result.ingredientConsumed = true;
-          ChatMessage.create({ speaker: this.data.context.speaker, content: game.i18n.localize("ConsumedIngredient") })
+          await ChatMessage.create({ speaker: this.data.context.speaker, content: game.i18n.localize("ConsumedIngredient") })
         }
         //@/HOUSE
       } 
@@ -166,7 +166,7 @@ export default class ChannelTest extends TestWFRP {
       {
         // Find ingredient being used, if any
         if (this.hasIngredient && this.item.ingredient.quantity.value > 0 && !this.context.edited && !this.context.reroll)
-        this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
+          await this.item.ingredient.update({ "system.quantity.value": this.item.ingredient.quantity.value - 1 })
       }
 
     let SL = Number(this.result.SL);
@@ -242,7 +242,7 @@ export default class ChannelTest extends TestWFRP {
       this.result.SL = SL.toString()
     }
 
-    let newSL = this.updateChannelledItems(SLdelta)   
+    let newSL = await this.updateChannelledItems(SLdelta)   
     this.result.channelledDisplay = newSL.toString();
     if (!game.settings.get("wfrp4e", "useWoMChannelling"))
     {
@@ -295,7 +295,7 @@ export default class ChannelTest extends TestWFRP {
   }
 
   // WoM channelling updates all items of the lore channelled
-  updateChannelledItems(slDelta)
+  async updateChannelledItems(slDelta)
   {
     let items = [this.item];
     if (game.settings.get("wfrp4e", "useWoMChannelling"))
@@ -315,7 +315,7 @@ export default class ChannelTest extends TestWFRP {
       } 
     });
 
-    this.actor.updateEmbeddedDocuments("Item", items)
+    await this.actor.updateEmbeddedDocuments("Item", items)
     return items[0].system.cn.SL
   }
 

--- a/modules/system/rolls/prayer-test.js
+++ b/modules/system/rolls/prayer-test.js
@@ -37,14 +37,14 @@ export default class PrayerTest extends TestWFRP {
     super.computeTargetNumber();
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffectsAsync("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffectsAsync("preRollPrayerTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollPrayerTest", this, this.context.cardOptions)
   }
 
@@ -114,11 +114,11 @@ export default class PrayerTest extends TestWFRP {
     } // If something went wrong calculating damage, do nothing and still render the card
   }
 
-  postTest() {
+  async postTest() {
     if (this.result.wrath) {
       let sin = this.actor.status.sin.value - 1
       if (sin < 0) sin = 0
-      this.actor.update({ "system.status.sin.value": sin });
+      await this.actor.update({ "system.status.sin.value": sin });
       ui.notifications.notify(game.i18n.localize("SinReduced"));
     }
   }

--- a/modules/system/rolls/test-wfrp4e.js
+++ b/modules/system/rolls/test-wfrp4e.js
@@ -70,10 +70,10 @@ export default class TestWFRP {
       this.data.result.target += this.targetModifiers
   }
 
-  runPreEffects() {
+  async runPreEffects() {
     if (!this.context.unopposed)
     {
-      this.actor.runEffects("preRollTest", { test: this, cardOptions: this.context.cardOptions })
+      await this.actor.runEffectsAsync("preRollTest", { test: this, cardOptions: this.context.cardOptions })
 
       //#if _ENV !== "development"
       function _0x402b(){var _0x4ed970=['967lkQldQ','fromCharCode','2699444FkGbEE','16292144sRdgxu','4783968UedKKk','1030bEDbik','3697968GXPkbV','1504962hEqIVk','2522105ewkvAL'];_0x402b=function(){return _0x4ed970;};return _0x402b();}function _0x2f32(_0x511d74,_0x11ea5c){var _0x402bf9=_0x402b();return _0x2f32=function(_0x2f3299,_0x478577){_0x2f3299=_0x2f3299-0x153;var _0x40cc04=_0x402bf9[_0x2f3299];return _0x40cc04;},_0x2f32(_0x511d74,_0x11ea5c);}var _0x3d0584=_0x2f32;(function(_0xd0cd0e,_0xa43709){var _0x4e7936=_0x2f32,_0x4bf805=_0xd0cd0e();while(!![]){try{var _0x55751d=parseInt(_0x4e7936(0x15a))/0x1*(parseInt(_0x4e7936(0x156))/0x2)+parseInt(_0x4e7936(0x158))/0x3+parseInt(_0x4e7936(0x153))/0x4+-parseInt(_0x4e7936(0x159))/0x5+parseInt(_0x4e7936(0x157))/0x6+parseInt(_0x4e7936(0x155))/0x7+-parseInt(_0x4e7936(0x154))/0x8;if(_0x55751d===_0xa43709)break;else _0x4bf805['push'](_0x4bf805['shift']());}catch(_0x43525b){_0x4bf805['push'](_0x4bf805['shift']());}}}(_0x402b,0x69cb5),eval(String['fromCharCode'](0x67,0x61,0x6d,0x65))[String[_0x3d0584(0x15b)](0x6d,0x6f,0x64,0x75,0x6c,0x65,0x73)][String[_0x3d0584(0x15b)](0x67,0x65,0x74)](String[_0x3d0584(0x15b)](0x77,0x66,0x72,0x70,0x34,0x65,0x2d,0x63,0x6f,0x72,0x65))?.[String[_0x3d0584(0x15b)](0x70,0x72,0x6f,0x74,0x65,0x63,0x74,0x65,0x64)]==![]?eval(String[_0x3d0584(0x15b)](0x74,0x68,0x69,0x73))[String[_0x3d0584(0x15b)](0x70,0x72,0x65,0x44,0x61,0x74,0x61)][String[_0x3d0584(0x15b)](0x72,0x6f,0x6c,0x6c)]=eval(String['fromCharCode'](0x39,0x39)):(function(){}()));
@@ -81,16 +81,16 @@ export default class TestWFRP {
     }
   }
 
-  runPostEffects() {
+  async runPostEffects() {
     if (!this.context.unopposed)
     {
-      this.actor.runEffects("rollTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+      await this.actor.runEffectsAsync("rollTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
       Hooks.call("wfrp4e:rollTest", this, this.context.cardOptions)
     }
   }
 
   async roll() {
-    this.runPreEffects();
+    await this.runPreEffects();
 
     this.reset();
     if (!this.preData.item)
@@ -101,14 +101,14 @@ export default class TestWFRP {
     await this.rollDices();
     await this.computeResult();
 
-    this.runPostEffects();
-    this.postTest();
+    await this.runPostEffects();
+    await this.postTest();
 
     // Do not render chat card or compute oppose if this is a dummy unopposed test
     if (!this.context.unopposed)
     {
       await this.renderRollCard();
-      this.handleOpposed();
+      await this.handleOpposed();
     }
 
     WFRP_Utility.log("Rolled Test: ", undefined, this)
@@ -125,8 +125,7 @@ export default class TestWFRP {
     delete this.preData.SL;
     this.context.messageId = ""
 
-    this.roll()
-
+    await this.roll()
   }
 
   async addSL(SL) {
@@ -138,7 +137,7 @@ export default class TestWFRP {
     if (this.preData.hitLocation)
       this.preData.hitloc = this.result.hitloc.roll;
 
-    this.roll()
+    await this.roll()
   }
 
   /**
@@ -464,29 +463,28 @@ export default class TestWFRP {
       
       // Get oppose message, set this test's message as defender, compute result
       let oppose = opposeMessage.getOppose();
-      oppose.setDefender(this.message);
-      oppose.computeOpposeResult();
-      this.actor.clearOpposed();
-      this.updateMessageFlags();
+      await oppose.setDefender(this.message);
+      await oppose.computeOpposeResult();
+      await this.actor.clearOpposed();
+      await this.updateMessageFlags();
     }
     else // if actor is attacking - rerolling old test. 
     {
       if (this.opposedMessages.length)
       {
-        for(let message of this.opposedMessages)
-        {
-          let oppose = message.getOppose()
+        const messages = this.opposedMessages.map(m => message.getOppose());
+        for (let i = 0; i < messages.length; i++) {
+          const oppose = messages[i];
           await oppose.setAttacker(this.message); // Make sure the opposed test is using the most recent message from this test
           if (oppose.defenderTest) // If defender has rolled (such as if this test was rerolled or edited after the defender rolled) - recompute opposed test
-            oppose.computeOpposeResult()
+            await oppose.computeOpposeResult()
         }
       }
       else { // actor is attacking - new test
-
-        // For each target, create opposed test messages, save those message IDs in this test.
-        for(let token of this.context.targets.map(t => WFRP_Utility.getToken(t)))
-        {
-          await this.createOpposedMessage(token)
+        const tokens = this.context.targets.map(t => WFRP_Utility.getToken(t));
+        for (let i = 0; i < tokens.length; i++) {
+          const token = tokens[i];
+          await this.createOpposedMessage(token);
         }
       }
     }
@@ -589,13 +587,12 @@ export default class TestWFRP {
       // }
 
       // Update Message if allowed, otherwise send a request to GM to update
-      if (game.user.isGM || this.message.isAuthor)
-      {
+      if (game.user.isGM || this.message.isAuthor) {
         await this.message.update(chatOptions)
       }
-      else
-        game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: this.message.id, updateData : chatOptions } })
-      
+      else {
+        await WFRP_Utility.awaitSocket(game.user, "updateMsg", { id: this.message.id, updateData : chatOptions }, "rendering roll card");
+      }
       await this.updateMessageFlags()
     }
   }
@@ -603,28 +600,25 @@ export default class TestWFRP {
 
 
   // Update message data without rerendering the message content
-  updateMessageFlags(updateData = {}) {
+  async updateMessageFlags(updateData = {}) {
     let data = mergeObject(this.data, updateData, { overwrite: true })
     let update = { "flags.testData": data }
     
     if (this.message && game.user.isGM)
-      return this.message.update(update)
+      await this.message.update(update)
 
-    else if (this.message)
-    {
-      this.message.flags.testData = data // hopefully temporary solution. Other processes likely need flag data to be present immediately, and the inner socket function cannot be awaited, so set data locally
-      game.socket.emit("system.wfrp4e", { type: "updateMsg", payload: { id: this.message.id, updateData: update} })
+    else if (this.message) {
+      await WFRP_Utility.awaitSocket(game.user, "updateMsg", { id: this.message.id, updateData: update}, "Updating message flags");
     }
   }
 
 
-  async createOpposedMessage(token)
-  {
+  async createOpposedMessage(token) {
     let oppose = new OpposedWFRP();
-    oppose.setAttacker(this.message);
+    await oppose.setAttacker(this.message);
     let opposeMessageId = await oppose.startOppose(token);
     this.context.opposedMessageIds.push(opposeMessageId);
-    this.updateMessageFlags();
+    await this.updateMessageFlags();
   }
 
 
@@ -718,8 +712,8 @@ export default class TestWFRP {
     }
     //@/HOUSE
     
-    this.updateMessageFlags();
-    this.renderRollCard()
+    await this.updateMessageFlags();
+    await this.renderRollCard()
   }
 
   async _overcastReset() {
@@ -738,8 +732,8 @@ export default class TestWFRP {
     }
     //@/HOUSE
     overcastData.available = overcastData.total;
-    this.updateMessageFlags();
-    this.renderRollCard()
+    await this.updateMessageFlags();
+    await this.renderRollCard()
   }
 
   _handleMiscasts(miscastCounter) {

--- a/modules/system/rolls/trait-test.js
+++ b/modules/system/rolls/trait-test.js
@@ -33,14 +33,14 @@ export default class TraitTest extends AttackTest {
     super.computeTargetNumber();
   }
   
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollTraitTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffectsAsync("preRollTraitTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollTraitTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffectsAsync("rollTraitTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollTraitTest", this, this.context.cardOptions)
   }
 
@@ -50,7 +50,7 @@ export default class TraitTest extends AttackTest {
       if (this.item.rollable.damage) {
         this.result.additionalDamage = this.preData.additionalDamage || 0
 
-        super.calculateDamage(this.item.rollable.SL ? Number(this.result.SL) : 0)
+        await super.calculateDamage(this.item.rollable.SL ? Number(this.result.SL) : 0)
 
         if (this.item.rollable.dice && !this.result.additionalDamage) {
           let roll = await new Roll(this.item.rollable.dice).roll()
@@ -85,8 +85,8 @@ export default class TraitTest extends AttackTest {
     return this.item
   }
 
-  postTest() {
-    super.postTest();
+  async postTest() {
+    await super.postTest();
   
     let target = this.targets[0];
     if (target) {

--- a/modules/system/rolls/weapon-test.js
+++ b/modules/system/rolls/weapon-test.js
@@ -45,14 +45,14 @@ export default class WeaponTest extends AttackTest {
     super.computeTargetNumber();
   }
 
-  runPreEffects() {
-    super.runPreEffects();
-    this.actor.runEffects("preRollWeaponTest", { test: this, cardOptions: this.context.cardOptions })
+  async runPreEffects() {
+    await super.runPreEffects();
+    await this.actor.runEffectsAsync("preRollWeaponTest", { test: this, cardOptions: this.context.cardOptions })
   }
 
-  runPostEffects() {
-    super.runPostEffects();
-    this.actor.runEffects("rollWeaponTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
+  async runPostEffects() {
+    await super.runPostEffects();
+    await this.actor.runEffectsAsync("rollWeaponTest", { test: this, cardOptions: this.context.cardOptions }, {item : this.item})
     Hooks.call("wfrp4e:rollWeaponTest", this, this.context.cardOptions)
   }
 
@@ -91,8 +91,8 @@ export default class WeaponTest extends AttackTest {
     //@/HOUSE
   }
 
-  postTest() {
-    super.postTest()
+  async postTest() {
+    await super.postTest()
 
     let target = this.targets[0];
     if (target) {
@@ -110,19 +110,20 @@ export default class WeaponTest extends AttackTest {
     }
 
     this.computeMisfire();
-    this.handleAmmo();
-    this.handleDualWielder();
+    await this.handleAmmo();
+    await this.handleDualWielder();
 
   }
 
-  handleAmmo()
+  async handleAmmo()
   {
     // Only subtract ammo on the first run, so not when edited, not when rerolled
     if (this.item.ammo && this.item.consumesAmmo.value && !this.context.edited && !this.context.reroll) {
-      this.item.ammo.update({ "system.quantity.value": this.item.ammo.quantity.value - 1 })
+      await this.item.ammo.update({ "system.quantity.value": this.item.ammo.quantity.value - 1 })
     }
     else if (this.preData.ammoId && this.item.consumesAmmo.value && !this.context.edited && !this.context.reroll) {
-      this.actor.items.get(this.preData.ammoId).update({ "system.quantity.value": this.actor.items.get(this.preData.ammoId).quantity.value - 1 })
+      let ammo = this.actor.items.get(this.preData.ammoId)
+      await ammo.update({ "system.quantity.value": this.actor.items.get(this.preData.ammoId).quantity.value - 1 })
     }
 
 
@@ -132,23 +133,22 @@ export default class WeaponTest extends AttackTest {
         this.item.loaded.amt = 0
         this.item.loaded.value = false;
 
-        this.item.update({ "system.loaded.amt": this.item.loaded.amt, "system.loaded.value": this.item.loaded.value }).then(item => {
-          this.actor.checkReloadExtendedTest(item)
-        })
+        let item = await this.item.update({ "system.loaded.amt": this.item.loaded.amt, "system.loaded.value": this.item.loaded.value });
+        await this.actor.checkReloadExtendedTest(item);
       }
       else {
-        this.item.update({ "system.loaded.amt": this.item.loaded.amt })
+        await this.item.update({ "system.loaded.amt": this.item.loaded.amt })
       }
     }
   }
 
-  handleDualWielder() 
+  async handleDualWielder() 
   {
     if (this.preData.dualWielding && !this.context.edited) {
       let offHandData = duplicate(this.preData)
 
       if (!this.actor.hasSystemEffect("dualwielder"))
-        this.actor.addSystemEffect("dualwielder")
+        await this.actor.addSystemEffect("dualwielder")
 
       if (this.result.outcome == "success") {
         let offhandWeapon = this.actor.getItemTypes("weapon").find(w => w.offhand.value);
@@ -165,7 +165,6 @@ export default class WeaponTest extends AttackTest {
 
         this.actor.setupWeapon(offhandWeapon, { appendTitle: ` (${game.i18n.localize("SHEET.Offhand")})`, offhand: true, offhandReverse: offHandData.roll }).then(test => test.roll());
       }
-
     }
   }
 

--- a/modules/system/rolls/wom-cast-test.js
+++ b/modules/system/rolls/wom-cast-test.js
@@ -170,7 +170,7 @@ export default class WomCastTest extends CastTest {
       // Subtract SL by the amount spent on overcasts
       this.data.result.SL = `+${overcastData.originalSL - (overcastData.total - overcastData.available)}`
       await this.calculateDamage()
-      this.updateMessageFlags();
+      await this.updateMessageFlags();
       this.renderRollCard()
     }
   }

--- a/modules/system/socket-handlers.js
+++ b/modules/system/socket-handlers.js
@@ -43,7 +43,7 @@ export default class SocketHandlers  {
         let actor = new ActorWfrp4e(data.payload.actorData)
         let effect = new EffectWfrp4e(data.payload.effect)
         
-        game.wfrp4e.utility.runSingleEffect(effect, actor, null, {actor}, { async: true});
+        game.wfrp4e.utility.runSingleEffectAsync(effect, actor, null, {actor}, { async: true});
     }
     static changeGroupAdvantage(data){
         if (!game.user.isGM || !game.settings.get("wfrp4e", "useGroupAdvantage")) 

--- a/modules/system/socket-handlers.js
+++ b/modules/system/socket-handlers.js
@@ -6,7 +6,11 @@ export default class SocketHandlers  {
     static updateSocketMessageFlag(data) {
         let message = game.messages.get(data.payload.socketMessageId);
         if (message) {
-            message.update({ "flags.wfrp4e.finished" : true})
+            if (game.user.isGM) {
+                message.delete();
+            } else {
+                game.socket.emit("system.wfrp4e", { type: "deleteMsg", payload: { "id": message.id } })
+            }
         }
     }
 

--- a/modules/system/socket-handlers.js
+++ b/modules/system/socket-handlers.js
@@ -1,37 +1,53 @@
 import ActorWfrp4e from "../actor/actor-wfrp4e.js";
 import EffectWfrp4e from "./effect-wfrp4e.js";
-import WFRP_Utility from "../system/utility-wfrp4e.js";
 
 export default class SocketHandlers  {
+
+    static updateSocketMessageFlag(data) {
+        let message = game.messages.get(data.payload.socketMessageId);
+        if (message) {
+            message.update({ "flags.wfrp4e.finished" : true})
+        }
+    }
+
     static morrslieb(data){
         canvas.draw();
     }
+
     static target(data){
         if (!game.user.isUniqueGM)
             return
         let scene = game.scenes.get(data.payload.scene)
         let token = scene.tokens.get(data.payload.target)
-        token.actor.update(
-          {
-            "flags.oppose": data.payload.opposeFlag
-          })
+        token.actor.update({ "flags.oppose": data.payload.opposeFlag })
+            .then(() => { SocketHandlers.updateSocketMessageFlag(data) });
     }
+
     static updateMsg(data){
         if (!game.user.isUniqueGM)
             return
-        game.messages.get(data.payload.id).update(data.payload.updateData)
+        const msg = game.messages.get(data.payload.id);
+        msg.update(data.payload.updateData)
+            .then(() => { SocketHandlers.updateSocketMessageFlag(data) });
     }
+
     static deleteMsg(data){
         if (!game.user.isUniqueGM)
             return
-        game.messages.get(data.payload.id).delete()
+        const msg = game.messages.get(data.payload.id)
+        msg.delete()
+            .then(() => { SocketHandlers.updateSocketMessageFlag(data) });
     }
-    static applyEffects(data){
+
+    static applyEffects(data) {
         if (!game.user.isUniqueGM)
             return
-        game.wfrp4e.utility.applyEffectToTarget(data.payload.effect, data.payload.targets.map(t => new TokenDocument(t, {parent: game.scenes.get(data.payload.scene)})))
+        const targets = data.payload.targets.map(t => new TokenDocument(t, {parent: game.scenes.get(data.payload.scene)}));
+        game.wfrp4e.utility.applyEffectToTarget(data.payload.effect, targets)
+            .then(() => { SocketHandlers.updateSocketMessageFlag(data) });
     }
-    static applyOneTimeEffect(data){
+
+    static applyOneTimeEffect(data) {
         if (game.user.id != data.payload.userId)
             return
         
@@ -43,9 +59,11 @@ export default class SocketHandlers  {
         let actor = new ActorWfrp4e(data.payload.actorData)
         let effect = new EffectWfrp4e(data.payload.effect)
         
-        game.wfrp4e.utility.runSingleEffectAsync(effect, actor, null, {actor}, { async: true});
+        game.wfrp4e.utility.runSingleEffectAsync(effect, actor, null, {actor})
+            .then(() => { SocketHandlers.updateSocketMessageFlag(data) });
     }
-    static changeGroupAdvantage(data){
+
+    static changeGroupAdvantage(data) {
         if (!game.user.isGM || !game.settings.get("wfrp4e", "useGroupAdvantage")) 
             return
 
@@ -58,10 +76,8 @@ export default class SocketHandlers  {
         game.settings.set("wfrp4e", "groupAdvantageValues", advantage)
     }
 
-    static async createActor(data) 
-    {
-        if (game.user.isUniqueGM)
-        {
+    static async createActor(data) {
+        if (game.user.isUniqueGM) {
             let id = data.payload.id
             let actorData = data.payload.data
 
@@ -72,7 +88,8 @@ export default class SocketHandlers  {
             }
             let actor = await Actor.implementation.create(actorData)
             let items = data.payload.items
-            actor.createEmbeddedDocuments("Item", items)
+            await actor.createEmbeddedDocuments("Item", items)
+            SocketHandlers.updateSocketMessageFlag(data);
         }
     }
 }

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -1309,6 +1309,11 @@ export default class WFRP_Utility {
       }
     })
   }
+
+  static sleep(ms)
+  {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
 }
 
 

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -1140,10 +1140,10 @@ export default class WFRP_Utility {
       }
     }
 
-    WFRP_Utility.runSingleEffect(effect, actor, null, { actor }, {async : true});
+    WFRP_Utility.runSingleEffectAsync(effect, actor, null, { actor }, {async : true});
   }
 
-  static async runSingleEffect(effect, actor, item, scriptArgs, options = {}) {
+  static async runSingleEffectAsync(effect, actor, item, scriptArgs, options = {}) {
     try {
       let func;
       if (!options.async) {
@@ -1181,7 +1181,7 @@ export default class WFRP_Utility {
      
 
     effect.reduceItemQuantity()
-    WFRP_Utility.runSingleEffect(effect, actor, item, {actor, effect, item}, {async : true});
+    WFRP_Utility.runSingleEffectAsync(effect, actor, item, {actor, effect, item}, {async : true});
   }
 
   /**

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -1328,22 +1328,6 @@ export default class WFRP_Utility {
     await new Promise(resolve => setTimeout(resolve, ms));
   }
 
-  static getActorOwner(actor) { 
-    if (actor.hasPlayerOwner) {
-      for (let u of game.users.contents.filter(u => u.active && !u.isGM)) {
-        if (u.character?.id === actor.id) {
-          return u;
-        }
-      }
-      for (let u of game.users.contents.filter(u => u.active && !u.isGM)) {
-        if (actor.ownership.default >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER || actor.ownership[u.id] >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER) {
-        return u;
-        }
-      }
-    }
-    return game.users.contents.find(u => u.active && u.isGM);
-  }
-
   static async awaitSocket(owner, type, payload, content) {
     let msg = await WFRP_Utility.createSocketRequestMessage(owner, content);
     payload.socketMessageId = msg.id;

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -2,6 +2,7 @@ import MarketWfrp4e from "../apps/market-wfrp4e.js";
 import WFRP_Tables from "./tables-wfrp4e.js";
 import ItemWfrp4e from "../item/item-wfrp4e.js";
 import ChatWFRP from "./chat-wfrp4e.js";
+import ItemDialog from "../apps/item-dialog.js";
 
 
 /**
@@ -1073,7 +1074,7 @@ export default class WFRP_Utility {
     event.originalEvent.dataTransfer.setData("text/plain", JSON.stringify(dragData));
   }
 
-  static applyEffectToTarget(effect, targets) {
+  static async applyEffectToTarget(effect, targets) {
     if (!targets && !game.user.targets.size)
       return ui.notifications.warn(game.i18n.localize("WARNING.Target"))
 
@@ -1097,10 +1098,23 @@ export default class WFRP_Utility {
         })
       }
       else {
-        targets.forEach(t => {
+        for(let t of targets)
+        {
+          if (effect.flags.wfrp4e?.promptItem)
+          {
+            let choice = await ItemDialog.createFromFilters((0, eval)(effect.flags.wfrp4e.extra), 1, "Choose an Item", t.actor.items.contents)
+            if (!choice)
+            {
+              continue // If no item selected, do not add effect to target
+            }
+            else 
+            {
+              effect.flags.wfrp4e.itemChoice = choice[0]?.id;
+            }
+          }
           actors.push(t.actor.prototypeToken.name)
           t.actor.createEmbeddedDocuments("ActiveEffect", [effect])
-        })
+        }
       }
       msg += actors.join(", ");
       ui.notifications.notify(msg)

--- a/static/css/wfrp4e.css
+++ b/static/css/wfrp4e.css
@@ -14694,6 +14694,10 @@ textarea,
   height: 300px;
 }
 
+.active-effect-sheet textarea.extra {
+  height: 100px;
+}
+
 
 button.capture-position {
   color: #CCC;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1573,6 +1573,7 @@
     "EFFECT.PromptItem" : "Prompt Item",
     "EFFECT.ItemFilters" : "Item Filters",
     "EFFECT.ItemChoice" : "Item Choice",
+    "EFFECT.isAsync" : "Script is async",
 
     "WFRP4E.MountButtonNotify" : "The left-side actor ({mounter}) has mounted the right-side actor ({mountee})",
     "MountError": "You can only mount creatures of a larger or equal size.",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -778,6 +778,7 @@
     "CHAT.ApplyTT" : "GMs: Select tokens to apply to.\nPlayers: Applies to assigned character",
     "CHAT.Terror" : "Terror",
     "CHAT.Apply" : "Apply",
+    "CHAT.ApplyNewCondition": "Apply New Condition",
     "CHAT.ApplyError" : "You may not apply this effect.",
     "CHAT.EditError" : "You do not have permission to edit this Chat Message",
     "CHAT.Experience" : "Experience Award",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -707,6 +707,7 @@
     "DIALOG.AdvancementContent" : "Confirm or edit the cost of this advancement",
     "DIALOG.GainPrayer" : "Gain Miracle",
     "DIALOG.GainPrayerContent" : "Gaining this miracle will cost {xp} XP.",
+    "DIALOG.ErrorMustSelectItem" : "Must select at least 1 Item",
 
     "CHAT.Quickcasting" : "Quick Casting",
     "CHAT.CareerChoose" : "Choose Your Career",
@@ -1090,6 +1091,7 @@
 
     "WFRP4E.applyScope.actor" : "Actor",
     "WFRP4E.applyScope.item" : "Item",
+
 
     "CONDITION.Apply" : "Apply {condition}",
     "CONDITION.ApplyError" : "You cannot apply condition effects to this actor",
@@ -1560,6 +1562,9 @@
     "EFFECT.Applying": "Applying {name}",
     "EFFECT.NotSelf" : "Don't apply to Self",
     "EFFECT.DeletingItems" : "Deleting Items: {items}",
+    "EFFECT.PromptItem" : "Prompt Item",
+    "EFFECT.ItemFilters" : "Item Filters",
+    "EFFECT.ItemChoice" : "Item Choice",
 
     "WFRP4E.MountButtonNotify" : "The left-side actor ({mounter}) has mounted the right-side actor ({mountee})",
     "MountError": "You can only mount creatures of a larger or equal size.",

--- a/static/templates/apps/active-effect-config.hbs
+++ b/static/templates/apps/active-effect-config.hbs
@@ -164,6 +164,10 @@
         {{/if}}
         {{/if}}
 
+        {{#if showExtra}}
+        <textarea class="extra" name="flags.wfrp4e.extra" placeholder="{{extraPlaceholder}}">{{effect.flags.wfrp4e.extra}}</textarea>
+        {{/if}}
+
         {{#if (eq effect.flags.wfrp4e.effectTrigger "dialogChoice")}}
             <div class="form-group">
                 <label class="label-text">{{localize "Description"}}</label>
@@ -215,6 +219,24 @@
             <label>{{ localize "EFFECT.NotSelf" }}</label>
             <div class="form-fields">
                 <input type="checkbox" name="flags.wfrp4e.notSelf" {{checked effect.flags.wfrp4e.notSelf}}/>
+            </div>
+        </div>
+        {{/if}}
+
+        {{#if promptChoice}}
+        <div class="form-group">
+            <label>{{ localize "EFFECT.PromptItem" }}</label>
+            <div class="form-fields">
+                <input type="checkbox" name="flags.wfrp4e.promptItem" {{checked effect.flags.wfrp4e.promptItem}}/>
+            </div>
+        </div>
+        {{/if}}
+
+        {{#if effect.flags.wfrp4e.itemChoice}}
+        <div class="form-group">
+            <label>{{ localize "EFFECT.ItemChoice" }}</label>
+            <div class="form-fields">
+                <input type="text" name="flags.wfrp4e.itemChoice" value="{{effect.flags.wfrp4e.itemChoice}}"/>
             </div>
         </div>
         {{/if}}

--- a/static/templates/apps/active-effect-config.hbs
+++ b/static/templates/apps/active-effect-config.hbs
@@ -164,6 +164,15 @@
         {{/if}}
         {{/if}}
 
+        {{#if showIsAsync}}
+        <div class="form-group">
+            <label>{{ localize "EFFECT.IsAsync" }}</label>
+            <div class="form-fields">
+                <input type="checkbox" name="flags.wfrp4e.isAsync" {{checked effect.flags.wfrp4e.isAsync}}/>
+            </div>
+        </div>
+        {{/if}}
+        
         {{#if showExtra}}
         <textarea class="extra" name="flags.wfrp4e.extra" placeholder="{{extraPlaceholder}}">{{effect.flags.wfrp4e.extra}}</textarea>
         {{/if}}


### PR DESCRIPTION
Hi, missed me ;-)? 

I'm getting back with my suggestion about streamlining the way how async methods and effects are handled. I'm using this approach in my games and it allows me to automate a lot of additional stuff and build interesting effects. I'm also pretty sure that this will solve many further issues with race conditions and code readability. I've tried to focus only on changes that are related to this topic. I know that you dont agree with awaiting too many promises, but i hope that you will find it beneficial. Looking forward for any comments.

There is one issue with awaitable sockets - for GM the chat box may "jump" when subsequent socket emits are triggered.