### PR TITLE
CSS compatibility for module Chat Commander

### DIFF
--- a/static/css/wfrp4e.css
+++ b/static/css/wfrp4e.css
@@ -1422,7 +1422,7 @@
       margin: 11px 11px 11px 11px;
       padding: 5px;
       resize: none;
-      border: none;
+      border: 3px solid #00000000;
       border-radius: 0px;
       background: none;
       font-family: var(--actor-input-font-family);

--- a/static/css/wfrp4e.css
+++ b/static/css/wfrp4e.css
@@ -1430,8 +1430,10 @@
       font-weight: var(--actor-input-font-weight);
       color: var(--actor-input-color);
       line-height: normal;
-      border: 3px double #3e000078;
     }
+     #chat-form textarea#chat-message {
+      border: 3px double #3e000078;
+     }
      #chat-form textarea:focus {
       outline: none;
       box-shadow: none;


### PR DESCRIPTION
[Chat Commander](https://foundryvtt.com/packages/_chatcommands) is a chat command autocompletion/helper module.

It creates a phantom textarea for its own use, but it receives the WFRP4e's border style, which shows up in the middle of the box as shown on the video below.

![](https://i.gyazo.com/f6c6bfbfc034c29e13dff4f0e1c2c589.gif)

Proposed changes would ensure that `border` attribute is applied only to the real chat message textarea.