### PR TITLE
Add clickable property link for rich text editors

### DIFF
--- a/modules/actor/sheet/actor-sheet.js
+++ b/modules/actor/sheet/actor-sheet.js
@@ -721,6 +721,7 @@ export default class ActorSheetWfrp4e extends ActorSheet {
     html.on("click", ".chat-roll", WFRP_Utility.handleRollClick.bind(WFRP_Utility))
     html.on("click", ".symptom-tag", WFRP_Utility.handleSymptomClick.bind(WFRP_Utility))
     html.on("click", ".condition-chat", WFRP_Utility.handleConditionClick.bind(WFRP_Utility))
+    html.on("click", ".property-chat", WFRP_Utility.handlePropertyClick.bind(WFRP_Utility))
     html.on('mousedown', '.table-click', WFRP_Utility.handleTableClick.bind(WFRP_Utility))
     html.on('mousedown', '.pay-link', WFRP_Utility.handlePayClick.bind(WFRP_Utility))
     html.on('mousedown', '.credit-link', WFRP_Utility.handleCreditClick.bind(WFRP_Utility))

--- a/modules/hooks/journal.js
+++ b/modules/hooks/journal.js
@@ -27,6 +27,7 @@ export default function() {
     html.find(".chat-roll").click(WFRP_Utility.handleRollClick.bind(WFRP_Utility))
     html.find(".symptom-tag").click(WFRP_Utility.handleSymptomClick.bind(WFRP_Utility))
     html.find(".condition-chat").click(WFRP_Utility.handleConditionClick.bind(WFRP_Utility))
+    html.find(".property-chat").click(WFRP_Utility.handlePropertyClick.bind(WFRP_Utility))
     html.find('.table-click').mousedown(WFRP_Utility.handleTableClick.bind(WFRP_Utility))
     html.find('.pay-link').mousedown(WFRP_Utility.handlePayClick.bind(WFRP_Utility))
     html.find('.credit-link').mousedown(WFRP_Utility.handleCreditClick.bind(WFRP_Utility))

--- a/modules/item/item-sheet.js
+++ b/modules/item/item-sheet.js
@@ -230,6 +230,7 @@ export default class ItemSheetWfrp4e extends ItemSheet {
     html.on("click", ".chat-roll", WFRP_Utility.handleRollClick.bind(WFRP_Utility))
     html.on("click", ".symptom-tag", WFRP_Utility.handleSymptomClick.bind(WFRP_Utility))
     html.on("click", ".condition-chat", WFRP_Utility.handleConditionClick.bind(WFRP_Utility))
+    html.on("click", ".property-chat", WFRP_Utility.handlePropertyClick.bind(WFRP_Utility))
     html.on('mousedown', '.table-click', WFRP_Utility.handleTableClick.bind(WFRP_Utility))
     html.on('mousedown', '.pay-link', WFRP_Utility.handlePayClick.bind(WFRP_Utility))
     html.on('mousedown', '.credit-link', WFRP_Utility.handleCreditClick.bind(WFRP_Utility))

--- a/modules/system/chat-wfrp4e.js
+++ b/modules/system/chat-wfrp4e.js
@@ -80,6 +80,7 @@ export default class ChatWFRP {
 
     html.on("click", ".symptom-tag", WFRP_Utility.handleSymptomClick.bind(WFRP_Utility))
     html.on("click", ".condition-chat", WFRP_Utility.handleConditionClick.bind(WFRP_Utility))
+    html.on("click", ".property-chat", WFRP_Utility.handlePropertyClick.bind(WFRP_Utility))
     html.on('mousedown', '.table-click', WFRP_Utility.handleTableClick.bind(WFRP_Utility))
     html.on('mousedown', '.pay-link', WFRP_Utility.handlePayClick.bind(WFRP_Utility))
     html.on('mousedown', '.credit-link', WFRP_Utility.handleCreditClick.bind(WFRP_Utility))

--- a/modules/system/config-wfrp4e.js
+++ b/modules/system/config-wfrp4e.js
@@ -168,6 +168,18 @@ CONFIG.TextEditor.enrichers = CONFIG.TextEditor.enrichers.concat([
         }
     },
     {
+        pattern : /@Property\[(.+?)](?:{(.+?)})?/gm,
+        enricher : (match) => {
+            const a = document.createElement("a");
+            a.classList.add("property-chat");
+            a.dataset.cond = match[1];
+            let id = match[1];
+            let label = match[2];
+            a.innerHTML = `<i class="fas fa-wrench"></i>${label ? label : id}`;
+            return a;
+        }
+    },
+    {
         pattern : /@Pay\[(.+?)\](?:{(.+?)})?/gm,
         enricher : (match, options) => {
             const a = document.createElement("a")

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -907,6 +907,28 @@ export default class WFRP_Utility {
   }
 
   /**
+   * Post property description when clicked.
+   *
+   * @param {Object} event click event
+   */
+  static handlePropertyClick(event) {
+    let prop = event.target.text.trim();
+
+    // If property rating is present, remove it
+    if (!isNaN(prop.split(" ").pop()))
+      prop = prop.split(" ").slice(0, -1).join(" ");
+
+    const allProps = game.wfrp4e.utility.allProperties();
+    const propKey = WFRP_Utility.findKey(prop, allProps, { caseInsensitive: true });
+    const propName = allProps[propKey];
+    const description = game.wfrp4e.config.qualityDescriptions[propKey] || game.wfrp4e.config.flawDescriptions[propKey];
+    const messageContent = `<b>${propName}</b><br>${description}`;
+
+    const chatData = WFRP_Utility.chatDataSetup(messageContent, null);
+    ChatMessage.create(chatData);
+  }
+
+  /**
    * Post symptom when clicked
    * 
    * @param {Object} event click event

--- a/static/css/wfrp4e.css
+++ b/static/css/wfrp4e.css
@@ -14803,6 +14803,7 @@ button.capture-position {
 
 .aoe-template,
 .condition-chat,
+.property-chat,
 .chat-roll,
 .table-click,
 .travel-click,


### PR DESCRIPTION
Allows using `@Property[key]{label)` format to create a clickable links.

When clicked, they will push Property's description to chat, similarly to `@Condition` syntax. 

![image](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/070edee3-80fa-4e73-94af-5a5dd3182100)
