### PR TITLE
Show ammunition's location in the ammo select dropdown menu

### DIFF
--- a/modules/actor/sheet/actor-sheet.js
+++ b/modules/actor/sheet/actor-sheet.js
@@ -311,6 +311,12 @@ export default class ActorSheetWfrp4e extends ActorSheet {
     inContainers = this._filterItemCategory(money, inContainers)
     inContainers = this._filterItemCategory(containers, inContainers)
 
+    // Add names of containers to item.location object. Used for ammo selection
+    inContainers.forEach(i => {
+      const container = this.actor.getItemTypes("container").find(c => c.id === i.location.value);
+      i.location.name = container.name || false;
+    });
+
     misc.totalShieldDamage = categories["weapons"].items.reduce((prev, current) => prev += current.damageToItem.shield, 0)
 
     money.total = money.items.reduce((prev, current) => { return prev + (current.coinValue.value * current.quantity.value) }, 0)

--- a/modules/actor/sheet/character-sheet.js
+++ b/modules/actor/sheet/character-sheet.js
@@ -46,6 +46,9 @@ export default class ActorSheetWfrp4eCharacter extends ActorSheetWfrp4e {
 
     this.addCharacterData(sheetData)
 
+     console.log('haha');
+     console.log(sheetData);
+
     return sheetData;
   }
 

--- a/modules/actor/sheet/character-sheet.js
+++ b/modules/actor/sheet/character-sheet.js
@@ -44,10 +44,7 @@ export default class ActorSheetWfrp4eCharacter extends ActorSheetWfrp4e {
   async getData() {
     const sheetData = await super.getData();
 
-    this.addCharacterData(sheetData)
-
-     console.log('haha');
-     console.log(sheetData);
+    this.addCharacterData(sheetData);
 
     return sheetData;
   }

--- a/static/templates/actors/actor-combat.hbs
+++ b/static/templates/actors/actor-combat.hbs
@@ -128,7 +128,7 @@
           {{#select item.currentAmmo.value}}
           <option class="ammo-option" value="">{{localize "NoneAmmo"}}</option>
           {{#each item.ammoList as |ammo a|}}
-          <option class="ammo-option" value="{{ammo.id}}"> ({{ammo.quantity.value}}) {{ammo.name}}</option>
+          <option class="ammo-option" value="{{ammo.id}}"> ({{ammo.quantity.value}}) {{ammo.name}} {{#if ammo.location.name}}– {{ammo.location.name}}{{/if}}</option>
           {{/each}}
           {{/select}}
         </select>

--- a/static/templates/actors/vehicle/vehicle-main.hbs
+++ b/static/templates/actors/vehicle/vehicle-main.hbs
@@ -207,7 +207,7 @@
           {{#select item.currentAmmo.value}}
           <option class="ammo-option" value="0">{{localize "NoneAmmo"}}</option>
           {{#each item.ammoList as |ammo a|}}
-          <option class="ammo-option" value="{{ammo.id}}"> ({{ammo.quantity.value}}) {{ammo.name}}</option>
+          <option class="ammo-option" value="{{ammo.id}}"> ({{ammo.quantity.value}}) {{ammo.name}} {{#if ammo.location.name}}– {{ammo.location.name}}{{/if}}</option>
           {{/each}}
           {{/select}}
         </select>


### PR DESCRIPTION
When a player has arrows in several containers, game doesn't let them know which arrows are they using. The only distinction would be the quantity or the name.

This poses several issues, especially if some of the ammunition was left behind in a Tavern, or if people play with additional rules for quivers etc. 

This PR adds container's name to the ammo select to alleviate all of those issues.

## Example ammo setup
![ammo setup](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/d18a1674-396b-4888-a997-77e9598fdfa6)

## How it looked before
![ammo before](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/88ac0f0d-e38e-4285-9424-7720b4b131e6)

## How it looks now
![ammo after](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/2387f2d6-dd59-4ceb-8d73-7aeeca245bb6)
