### PR TITLE
Fixed `ammoRange` related errors

### DIFF
--- a/modules/item/item-wfrp4e.js
+++ b/modules/item/item-wfrp4e.js
@@ -1207,14 +1207,19 @@ export default class ItemWfrp4e extends Item {
       value *= 2;
     else // If the range modification is a formula (supports +X -X /X *X)
     {
-      try // Works for + and -
-      {
-        ammoValue = (0, eval)(ammoValue);
-        value = Math.floor((0, eval)(value + ammoValue));
-      }
-      catch // if *X and /X
-      {                                      // eval (50 + "/5") = eval(50/5) = 10
-        value = Math.floor((0, eval)(value + ammoRange));
+      try {
+        try // Works for + and -
+        {
+          ammoValue = (0, eval)(ammoValue);
+          value = Math.floor((0, eval)(value + ammoValue));
+        }
+        catch // if *X and /X
+        {                                      // eval (50 + "/5") = eval(50/5) = 10
+          value = Math.floor((0, eval)(value + ammoValue));
+        }
+      } catch (error) {
+        ui.notifications.error(game.i18n.format("ERROR.AMMO_MODS", {type}));
+        console.error(error, {value, type, item: this, ammo: this.ammo});
       }
     }
     return value

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1373,6 +1373,7 @@
     "APPLYREQUESTOWNER": "Apply Effect command sent to owner",
     "EFFECT.Applied" : "{name} applied to",
     "ERROR.EFFECT": "Error when running effect {effect}, please see the console (F12)",
+    "ERROR.AMMO_MODS": "Ammunition '{type}' value could not be resolved, aborting. Check console (F12) for details`",
     "SinReduced": "Sin reduced by 1",
     "TargetingCancelled": "Targeting canceled: Already opposing a test",
     "ERROR.Property": "WFRP4e Rolls must specify the item property",


### PR DESCRIPTION
This Pull Request fixes `ammoRange` typo (it has never been declared and I believe by analyzing the code it should be `ammoValue`. 

Additionally I've added graceful fallback in a form of extra `try…catch` wrapper in order to not block opening Actor Sheet, while still providing obvious Error for the users to know that something went wrong. 

Issue could be encountered when using worded modifiers that were not properly translated (for example item said `come arma` in Italian, but client was set to `English`), or when using multipliers like `*5` or `/5` as ammo range. 

Should be fully compatible with #1694 Pull Request. 