### PR TITLE
Add `Melee (Parry)` to skill list in Roll Dialog if weapon is Defensive

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -2675,10 +2675,10 @@ export default class ActorWfrp4e extends Actor {
         item.offhand.value &&
         !item.twohanded.value &&
         !(
+          this.isOpposing &&
           item.properties.qualities.defensive &&
           (item.weaponGroup.value === "parry" || !!options.usesMeleeParry)
-        ) &&
-        this.isOpposing
+        )
     ) {
       modifier -= 20;
       tooltip.push(`${game.i18n.localize("SHEET.Offhand")} (-20)`);

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -871,7 +871,7 @@ export default class ActorWfrp4e extends Actor {
       const parrySkill = this.itemCategories.skill.find(x => x.name.toLowerCase().includes(`(${game.wfrp4e.config.weaponGroups.parry.toLowerCase()})`))
 
       // Only add skill if it wasn't there already
-      if (skillCharList.some(s => s._id !== parrySkill._id)) {
+      if (!skillCharList.find(s => s.name === parrySkill.name)) {
         skillCharList.push(parrySkill);
 
         // default to skill if higher than skillToUse

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -876,8 +876,12 @@ export default class ActorWfrp4e extends Actor {
         skillCharList.push(parrySkill);
 
         // default to skill if higher than skillToUse
-        if (parrySkill.total.value > skillToUse.total.value)
+        if (parrySkill.total.value > skillToUse.total.value) {
           defaultSelection = skillCharList.findIndex(i => i.name === parrySkill.name)
+          options.usesMeleeParry = true;
+        }
+      } else {
+        options.usesMeleeParry = true;
       }
     }
 
@@ -2667,11 +2671,19 @@ export default class ActorWfrp4e extends Actor {
     let successBonus = 0;
     let modifier = 0;
 
-    // If offhand and should apply offhand penalty (should apply offhand penalty = not parry, not defensive, and not twohanded)
-    if (item.type == "weapon" && item.offhand.value && !item.twohanded.value && !(item.weaponGroup.value == "parry" && item.properties.qualities.defensive)) {
-      modifier = -20
+    // When defending, if offhand and should apply offhand penalty (should apply offhand penalty = not parry, not defensive, and not twohanded)
+    if (item.type === "weapon" &&
+        item.offhand.value &&
+        !item.twohanded.value &&
+        !(
+          item.properties.qualities.defensive &&
+          (item.weaponGroup.value === "parry" || !!options.usesMeleeParry)
+        ) &&
+        this.isOpposing
+    ) {
+      modifier -= 20;
       tooltip.push(`${game.i18n.localize("SHEET.Offhand")} (-20)`);
-      const ambiMod = Math.min(20, this.flags.ambi * 10)
+      const ambiMod = Math.min(20, this.flags.ambi * 10);
       modifier += ambiMod;
       if (this.flags.ambi)
         tooltip.push(`${game.i18n.localize("NAME.Ambi")} (+${ambiMod})`);

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -2,7 +2,6 @@ import WFRP_Utility from "../system/utility-wfrp4e.js";
 import WFRP_Audio from "../system/audio-wfrp4e.js";
 import RollDialog from "../apps/roll-dialog.js";
 import EffectWfrp4e from "../system/effect-wfrp4e.js"
-import WFRP4E from "../system/config-wfrp4e";
 
 /**
  * Provides the main Actor data computation and organization.


### PR DESCRIPTION
## Change no.1
CRB states that 
> Any one-handed weapon with the Defensive Quality can be used with Melee (Parry)

So my first change in commits (969ce525f2adce442665a00dda7c8a22d93d0bf9, 4b7f63632aab835a7273af9a27b557af99b555c1) adds option to roll dialog, where `Melee (Parry)` will appear if character uses a weapon with `Defensive` quality **and** if that character has `Melee (Parry)` skill. 

`Melee (Parry)` will be set as default if its `total` is higher than standard skill's. 
![image](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/ea2bb63e-6189-4f99-a709-7e409ee51946)


## Change no.2
My other commits (5b95e74b166b38dbf40649b0fb8b2112a39a8127, along with 4f5b63133c7c7077eb5a4d0221fd9746f0321d6f) tries to mitigate an issue reported by Canis here: https://discord.com/channels/787396882875416606/787397718339223603/1184475915783249990

> So, it does seem that the system does not apply the off hand penalty when attacking with a parry weapon.

So I added `this.isOpposing` check, to only mitigate penalty when **Opposing** tests with Parry weapon.

Furthermore, to make it more compatible with first commit, I added a `usesMeleeParry` option so I can check if Melee Parry is set as default, because the offhand penalty should not apply (quoting CRB) "When using Melee (Parry)", not when weapon group is `Parry`. Otherwise, it behaves as it did. 
