### PR TITLE
fixed `ammoRange` typo and added graceful fallback to not block opening

### DIFF
--- a/modules/model/item/weapon.js
+++ b/modules/model/item/weapon.js
@@ -351,14 +351,19 @@ export class WeaponModel extends PropertiesMixin(PhysicalItemModel) {
             value *= 2;
         else // If the range modification is a formula (supports +X -X /X *X)
         {
-            try // Works for + and -
-            {
-                ammoValue = (0, eval)(ammoValue);
-                value = Math.floor((0, eval)(value + ammoValue));
-            }
-            catch // if *X and /X
-            {                                      // eval (50 + "/5") = eval(50/5) = 10
-                value = Math.floor((0, eval)(value + ammoRange));
+            try {
+                try // Works for + and -
+                {
+                    ammoValue = (0, eval)(ammoValue);
+                    value = Math.floor((0, eval)(value + ammoValue));
+                }
+                catch // if *X and /X
+                {                                      // eval (50 + "/5") = eval(50/5) = 10
+                    value = Math.floor((0, eval)(value + ammoValue));
+                }
+            } catch (error) {
+                ui.notifications.error(game.i18n.format("ERROR.AMMO_MODS", {type}));
+                console.error(error, {value, type, item: this, ammo: this.ammo});
             }
         }
         return value

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1374,6 +1374,7 @@
     "APPLYREQUESTOWNER": "Apply Effect command sent to owner",
     "EFFECT.Applied" : "{name} applied to",
     "ERROR.EFFECT": "Error when running effect {effect}, please see the console (F12)",
+    "ERROR.AMMO_MODS": "Ammunition '{type}' value could not be resolved, aborting. Check console (F12) for details`",
     "SinReduced": "Sin reduced by 1",
     "TargetingCancelled": "Targeting canceled: Already opposing a test",
     "ERROR.Property": "WFRP4e Rolls must specify the item property",


### PR DESCRIPTION
Basically #1841 but made from `effect-refactor` branch, so it can be merged.


Closes #1841 