### PR TITLE
Disease code refactor (Part 1)

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -1305,7 +1305,7 @@ export default class ActorWfrp4e extends WFRP4eDocumentMixin(Actor)
     if (isNaN(injury.system.duration.value))
       return ui.notifications.notify(game.i18n.format("CHAT.InjuryError", { injury: injury.name }))
 
-    injury = foundry.utils.duplicate(injury);
+    injury = foundry.utils.deepClone(injury);
     injury.system.duration.value--;
 
     if (injury.system.duration.value <= 0) {
@@ -1337,7 +1337,7 @@ export default class ActorWfrp4e extends WFRP4eDocumentMixin(Actor)
    * @return {Promise<void>}
    */
   async decrementDisease(disease) {
-    let d = foundry.utils.duplicate(disease);
+    let d = foundry.utils.deepClone(disease);
     let type = d.system.duration.active ? 'duration' : 'incubation';
 
     if (Number.isNumeric(d.system[type].value)) {

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -1412,10 +1412,10 @@ export default class ActorWfrp4e extends WFRP4eDocumentMixin(Actor)
             msg += game.i18n.format("CHAT.LingeringExtended", { duration: roll });
           } else if (negSL <= 5) {
             msg += game.i18n.localize("CHAT.LingeringFestering");
-            lingeringDisease = await fromUuid("Compendium.wfrp4e-core.diseases.kKccDTGzWzSXCBOb");
+            lingeringDisease = await fromUuid("Compendium.wfrp4e-core.items.kKccDTGzWzSXCBOb");
           } else if (negSL >= 6) {
             msg += game.i18n.localize("CHAT.LingeringRot");
-            lingeringDisease = await fromUuid("Compendium.wfrp4e-core.diseases.M8XyRs9DN12XsFTQ");
+            lingeringDisease = await fromUuid("Compendium.wfrp4e-core.items.M8XyRs9DN12XsFTQ");
           }
 
           if (lingeringDisease)

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -1401,7 +1401,7 @@ export default class ActorWfrp4e extends WFRP4eDocumentMixin(Actor)
         let difficulty = lingering.name.substring(lingering.name.indexOf("(") + 1, lingering.name.indexOf(")")).toLowerCase();
 
         let test = await this.setupSkill(game.i18n.localize("NAME.Endurance"), { difficulty });
-        test.roll();
+        await test.roll();
 
         if (test.result.outcome === "failure") {
           let negSL = Math.abs(test.result.SL);

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -1347,10 +1347,10 @@ export default class ActorWfrp4e extends WFRP4eDocumentMixin(Actor)
         d.system[type].value = 0;
 
         if (type === 'incubation')
-          await actor.activateDisease(d);
+          await this.activateDisease(d);
 
         if (type === 'duration')
-          await actor.finishDisease(d);
+          await this.finishDisease(d);
       }
     } else {
       let chatData = game.wfrp4e.utility.chatDataSetup(`Attempted to decrement ${d.name} ${type} but value is non-numeric`, "gmroll", false);

--- a/modules/model/item/disease.js
+++ b/modules/model/item/disease.js
@@ -59,4 +59,9 @@ export class DiseaseModel extends BaseItemModel {
 
     return properties;
   }
+
+  shouldTransferEffect(effect)
+  {
+    return this.duration.active === true;
+  }
 }

--- a/modules/model/item/disease.js
+++ b/modules/model/item/disease.js
@@ -1,59 +1,62 @@
-import { BaseItemModel } from "./components/base";
+import {BaseItemModel} from "./components/base";
+
 let fields = foundry.data.fields;
 
 /**
  * Represents an Item used by both Patrons and Characters/NPCs
  */
-export class DiseaseModel extends BaseItemModel
-{
+export class DiseaseModel extends BaseItemModel {
 
-    static defineSchema() 
-    {
-        let schema = super.defineSchema();
-        schema.contraction = new fields.SchemaField({
-            value : new fields.StringField(),
-        });
-        
-        schema.incubation = new fields.SchemaField({
-            value : new fields.StringField(),
-        })
+  static defineSchema() {
+    let schema = super.defineSchema();
+    schema.contraction = new fields.SchemaField({
+      value: new fields.StringField(),
+    });
 
-        schema.duration = new fields.SchemaField({
-            value : new fields.StringField(),
-            unit : new fields.StringField(),
-            active : new fields.BooleanField(),
-        })
+    schema.incubation = new fields.SchemaField({
+      value: new fields.StringField(),
+    });
 
-        schema.symptoms = new fields.SchemaField({
-            value : new fields.StringField(),
-        })
+    schema.duration = new fields.SchemaField({
+      value: new fields.StringField(),
+      unit: new fields.StringField(),
+      active: new fields.BooleanField(),
+    });
 
-        schema.permanent = new fields.SchemaField({
-            value : new fields.StringField(),
-        })
-        return schema;
-    }
+    schema.symptoms = new fields.SchemaField({
+      value: new fields.StringField(),
+    });
 
-    async expandData(htmlOptions) {
-        let data = await super.expandData(htmlOptions);
-        data.properties.push(`<b>${game.i18n.localize("Contraction")}:</b> ${this.contraction.value}`);
-        data.properties.push(`<b>${game.i18n.localize("Incubation")}:</b> ${this.incubation.value} ${this.incubation.unit}`);
-        data.properties.push(`<b>${game.i18n.localize("Duration")}:</b> ${this.duration.value} ${this.duration.unit}`);
-        data.properties = data.properties.concat(this.parent.effects.map(i => i = "<a class ='symptom-tag'><i class='fas fa-user-injured'></i> " + i.name.trim() + "</a>").join(", "));
-        if (this.permanent.value)
-          data.properties.push(`<b>${game.i18n.localize("Permanent")}:</b> ${this.permanent.value}`);
-        return data;
-      }
+    schema.permanent = new fields.SchemaField({
+      value: new fields.StringField(),
+    });
 
-      chatData()
-      {
-        let properties = [];
-        properties.push(`<b>${game.i18n.localize("Contraction")}:</b> ${this.contraction.value}`);
-        properties.push(`<b>${game.i18n.localize("Incubation")}:</b> <a class = 'chat-roll'><i class='fas fa-dice'></i> ${this.incubation.value}</a>`);
-        properties.push(`<b>${game.i18n.localize("Duration")}:</b> <a class = 'chat-roll'><i class='fas fa-dice'></i> ${this.duration.value}</a>`);
-        properties.push(`<b>${game.i18n.localize("Symptoms")}:</b> ${(this.symptoms.value.split(",").map(i => i = "<a class ='symptom-tag'><i class='fas fa-user-injured'></i> " + i.trim() + "</a>")).join(", ")}`);
-        if (this.permanent.value)
-          properties.push(`<b>${game.i18n.localize("Permanent")}:</b> ${this.permanent.value}`);
-        return properties;
-      }
+    return schema;
+  }
+
+  async expandData(htmlOptions) {
+    let data = await super.expandData(htmlOptions);
+    data.properties.push(`<b>${game.i18n.localize("Contraction")}:</b> ${this.contraction.value}`);
+    data.properties.push(`<b>${game.i18n.localize("Incubation")}:</b> ${this.incubation.value} ${this.incubation.unit}`);
+    data.properties.push(`<b>${game.i18n.localize("Duration")}:</b> ${this.duration.value} ${this.duration.unit}`);
+    data.properties = data.properties.concat(this.parent.effects.map(i => i = "<a class ='symptom-tag'><i class='fas fa-user-injured'></i> " + i.name.trim() + "</a>").join(", "));
+
+    if (this.permanent.value)
+      data.properties.push(`<b>${game.i18n.localize("Permanent")}:</b> ${this.permanent.value}`);
+
+    return data;
+  }
+
+  chatData() {
+    let properties = [];
+    properties.push(`<b>${game.i18n.localize("Contraction")}:</b> ${this.contraction.value}`);
+    properties.push(`<b>${game.i18n.localize("Incubation")}:</b> <a class = 'chat-roll'><i class='fas fa-dice'></i> ${this.incubation.value}</a>`);
+    properties.push(`<b>${game.i18n.localize("Duration")}:</b> <a class = 'chat-roll'><i class='fas fa-dice'></i> ${this.duration.value}</a>`);
+    properties.push(`<b>${game.i18n.localize("Symptoms")}:</b> ${(this.symptoms.value.split(",").map(i => i = "<a class ='symptom-tag'><i class='fas fa-user-injured'></i> " + i.trim() + "</a>")).join(", ")}`);
+
+    if (this.permanent.value)
+      properties.push(`<b>${game.i18n.localize("Permanent")}:</b> ${this.permanent.value}`);
+
+    return properties;
+  }
 }

--- a/modules/model/item/disease.js
+++ b/modules/model/item/disease.js
@@ -9,7 +9,7 @@ export class DiseaseModel extends BaseItemModel
 
     static defineSchema() 
     {
-        let schema = {};
+        let schema = super.defineSchema();
         schema.contraction = new fields.SchemaField({
             value : new fields.StringField(),
         });


### PR DESCRIPTION
Refactored some of the code responsible for handling Actor's diseases. 

For the most part, changes could be described as one of the following:
- Styling improvements
- Reducing code duplication (DRY)
- Improving readability and adding JSDoc comments
- Replacing `.then()` syntax with `await` syntax inside `async` function


But there are also several instances of actual changes and improvements, such as:
- Adding `await` in places, where lack of it could lead to data loss and/or race conditions
- Fixing actual errors.

---
**More info in commit [review/comments](https://github.com/moo-man/WFRP4e-FoundryVTT/pull/1851/files).**

---
I realize that **most of these methods** will need an additional pass when Disease are migrated (currently, I am unable to created new Items on this branch because of migration errors). 

However, there are some lines that need an additional scrutiny:

~~### 1. Here, both "diseases" are not found in the compendiums, so `lingeringDisease` will always be `null`.~~
~~https://github.com/moo-man/WFRP4e-FoundryVTT/pull/1851/files#diff-c588f96685c7089ee5b43e41afbdb538af2993de610f58860343fe75a30cab2eR1414-R1418~~
Resolved in commits.

### 2. Here, the variable `removeEffects` was never defined (and if it were, it would already be an array, so the line itself is somewhat weird). 
https://github.com/moo-man/WFRP4e-FoundryVTT/pull/1851/files#diff-c588f96685c7089ee5b43e41afbdb538af2993de610f58860343fe75a30cab2eR1426
