### PR TITLE
Pass actual ActorWfrp4e instance to scripts 

### DIFF
--- a/modules/model/actor/standard.js
+++ b/modules/model/actor/standard.js
@@ -94,11 +94,11 @@ export class StandardActorModel extends BaseActorModel {
         flags.resolute = 0
         flags.ambi = 0;
 
-        this.parent.runScripts("prePrepareData", { actor: this })
+        this.parent.runScripts("prePrepareData", { actor: this.parent })
     }
 
     computeDerived() {
-        this.parent.runScripts("prePrepareItems", {actor : this})
+        this.parent.runScripts("prePrepareItems", {actor : this.parent })
         this.computeItems();
         super.computeDerived();
         // Recompute bonuses as active effects may have changed it
@@ -115,7 +115,7 @@ export class StandardActorModel extends BaseActorModel {
         this.computeAP();
         this.computeMount()
 
-        this.parent.runScripts("prepareData", { actor: this })
+        this.parent.runScripts("prepareData", { actor: this.parent })
     }
 
     computeAdvantage() {
@@ -265,7 +265,7 @@ export class StandardActorModel extends BaseActorModel {
         if (flags.autoCalcCritW)
             this.status.criticalWounds.max = tb;
 
-        let effectArgs = { sb, tb, wpb, multiplier, actor: this }
+        let effectArgs = { sb, tb, wpb, multiplier, actor: this.parent }
         this.parent.runScripts("preWoundCalc", effectArgs);
         ({ sb, tb, wpb } = effectArgs);
 
@@ -304,7 +304,7 @@ export class StandardActorModel extends BaseActorModel {
             }
         }
 
-        effectArgs = { wounds, actor: this }
+        effectArgs = { wounds, actor: this.parent }
         this.parent.runScripts("woundCalc", effectArgs);
         wounds = effectArgs.wounds;
         return wounds


### PR DESCRIPTION
Right now, on effects such as `Prepare Data`, the `args.actor` holds Actor's Data Model. This breaks some effects that rely on this, such as `Malaise` that uses `args.actor.hasCondition()` and `args.actor.addCondition()`.

Proposed PR will change it instead to Actor's actual instance so effect scripts can have unchanged access to the entire Actor Document. 