### PR TITLE
Fix Enter not working when editing effect scripts and/or macros

### DIFF
--- a/modules/apps/roll-dialog/roll-dialog.js
+++ b/modules/apps/roll-dialog/roll-dialog.js
@@ -373,7 +373,10 @@ export default class RollDialog extends Application {
 
     _onKeyPress(ev)
     {
-        if (ev.key == "Enter")
+        if (!this.rendered) return;
+        if (this !== ui.activeWindow) return;
+
+        if (ev.key === "Enter")
         {
             this.submit(ev); 
         }

--- a/modules/apps/roll-dialog/roll-dialog.js
+++ b/modules/apps/roll-dialog/roll-dialog.js
@@ -376,7 +376,7 @@ export default class RollDialog extends Application {
         if (!this.rendered) return;
         if (this !== ui.activeWindow) return;
 
-        if (ev.key === "Enter")
+        if (ev.key == "Enter")
         {
             this.submit(ev); 
         }


### PR DESCRIPTION
The issue when editing macros/effect scripts was because event listener for `Enter` was bound to Roll Dialog.

Last few days I was redoing Runes in my module, and that involves hours and hours of modifying script effects, testing etc. 
Normally `Enter` works properly and makes new line. However, during these few days, on several ocassions (like 4 or 5 times?), Enter stopped working in script Editor.

Today I finally was able to figure it out. (console helps, duh)

For whatever reason, **sometimes**, the Roll Dialog is not properly closed and its event listener is not being removed, so it is always listening, meaning that whenever user is focused on an element that doesn't override the keypress (so not chat window, canvas, form application etc, but textareas like Macro editor or Script Effect editor), the following error would appear in the console and would prevent new line from forming:

![image](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/e5a79e8e-4999-4734-8d9c-c97cb28fcd88)

It's very hard to reproduce (took me 30+ minutes of doing opposed tests in multiple ways to get that screenshot). And once I got it, I couldn't easily reproduce it again, so it seems random. 

Error points to `data.targets = Array.from(data.targets).map(t => t.actor.speakerData(t.document));`, but if you consider what would happen if this line happens more than once, it's clear that `t.document` would not exist in `data.targets` once it's converted to `speakerData`. But I don't think this is the issue, I think it's that randomly the Event Listener is not removed and Roll Dialog being submitted twice.


## Solution
I added two, somewhat reduntant checks. Now `Enter` will only submit Roll Dialog, if Roll Dialog: is rendered **and** is the Active Window. 

Since it's sort of a stop gap solution, it might not help with Event Listener randomly not being removed, but should mitigate any errors that this could lead to. 

Side effect (positive in my opinion) is that with Roll Dialog opened, `Enter` won't submit it if pressed while focus is on another Window