### PR TITLE
Add Combat Hooks

### DIFF
--- a/modules/system/combat.js
+++ b/modules/system/combat.js
@@ -77,7 +77,7 @@ export default class CombatHelpers {
                 await script(combat, previousCombatant);
             }
             await Promise.all(previousCombatant.actor.runScripts("endTurn", combat, previousCombatant));
-            Hooks.callAll("wfrp4e:startTurn", combat, previousCombatant);
+            Hooks.callAll("wfrp4e:endTurn", combat, previousCombatant);
         }
         if (currentCombatant) {
             for (let script of CombatHelpers.scripts.startTurn) {

--- a/modules/system/combat.js
+++ b/modules/system/combat.js
@@ -36,6 +36,7 @@ export default class CombatHelpers {
         }
         for (let turn of combat.turns) {
             await Promise.all(turn.actor.runScripts("startCombat", combat));
+            Hooks.callAll("wfrp4e:startCombat", combat);
         }
     }
 
@@ -66,6 +67,7 @@ export default class CombatHelpers {
                 
                 for (let turn of combat.turns) {
                     await Promise.all(turn.actor.runScripts("endRound", combat));
+                    Hooks.callAll("wfrp4e:endRound", combat);
                 }
             }
         }
@@ -74,13 +76,15 @@ export default class CombatHelpers {
             for (let script of CombatHelpers.scripts.endTurn) {
                 await script(combat, previousCombatant);
             }
-            await Promise.all(previousCombatant.actor.runScripts("endTurn", combat, previousCombatant))
+            await Promise.all(previousCombatant.actor.runScripts("endTurn", combat, previousCombatant));
+            Hooks.callAll("wfrp4e:startTurn", combat, previousCombatant);
         }
         if (currentCombatant) {
             for (let script of CombatHelpers.scripts.startTurn) {
                 await script(combat, currentCombatant);
             }
-            await Promise.all(currentCombatant.actor.runScripts("startTurn", combat, currentCombatant))
+            await Promise.all(currentCombatant.actor.runScripts("startTurn", combat, currentCombatant));
+            Hooks.callAll("wfrp4e:startTurn", combat, currentCombatant);
         }
     }
 
@@ -155,7 +159,8 @@ export default class CombatHelpers {
             ChatMessage.create({ content, whisper: ChatMessage.getWhisperRecipients("GM") })
         }
         for (let turn of combat.turns) {
-            await Promise.all(turn.actor.runScripts("endCombat", combat))
+            await Promise.all(turn.actor.runScripts("endCombat", combat));
+            Hooks.callAll("wfrp4e:endCombat", combat);
         }
     }
 


### PR DESCRIPTION
This PR adds several Hooks related to Combat that 3rd party modules can use.

Hooks match up with corresponding Active Effect triggers, always happening _after_ effects, and having the same arguments. 

This way, 3rd party modules could hook up (pun intended) to the common, system defined events, instead of trying to engineer their own checks of when turn starts, when it ends, what update says what etc.

Added Hooks:
- `wfrp4e:startCombat`
- `wfrp4e:startTurn`
- `wfrp4e:endTurn`
- `wfrp4e:endRound`
- `wfrp4e:endCombat`