### PR TITLE
Add support for RAW advancement cost option (depending on advances own)

### DIFF
--- a/modules/hooks/init.js
+++ b/modules/hooks/init.js
@@ -116,6 +116,16 @@ export default function() {
       type: Number
     });
 
+    // Register advancements rule
+    game.settings.register("wfrp4e", "rawAdvancements", {
+      name: "SETTINGS.UseRawAdvancements",
+      hint: "SETTINGS.UseRawAdvancementsHint",
+      scope: "world",
+      config: true,
+      default: false,
+      type: Boolean
+    });
+
     // Register Fast SL rule
     game.settings.register("wfrp4e", "fastSL", {
       name: "SETTINGS.FastSL",

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -4,6 +4,7 @@ import ItemWfrp4e from "../item/item-wfrp4e.js";
 import ChatWFRP from "./chat-wfrp4e.js";
 import ItemDialog from "../apps/item-dialog.js";
 import TestWFRP from "../system/rolls/test-wfrp4e.js";
+import settings from "../hooks/settings";
 
 
 /**
@@ -402,8 +403,13 @@ export default class WFRP_Utility {
    * @param {Number} modifier          Cost modifier per advancement
    */
   static _calculateAdvCost(currentAdvances, type, modifier = 0) {
-    let index = Math.floor(currentAdvances / 5);
-    index = index < 0 ? 0 : index; // min 0
+    let index;
+    if (game.settings.get("wfrp4e", "rawAdvancements"))
+      index = (Math.ceil(currentAdvances / 5) - 1);
+    else
+      index = Math.floor(currentAdvances / 5);
+
+    index = Math.max(0, index);
 
     if (index >= game.wfrp4e.config.xpCost[type].length)
       return game.wfrp4e.config.xpCost[type][game.wfrp4e.config.xpCost[type].length - 1] + modifier;

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -1,10 +1,6 @@
 import MarketWfrp4e from "../apps/market-wfrp4e.js";
-import WFRP_Tables from "./tables-wfrp4e.js";
 import ItemWfrp4e from "../item/item-wfrp4e.js";
 import ChatWFRP from "./chat-wfrp4e.js";
-import ItemDialog from "../apps/item-dialog.js";
-import TestWFRP from "../system/rolls/test-wfrp4e.js";
-import settings from "../hooks/settings";
 
 
 /**

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -59,6 +59,8 @@
     "SETTINGS.AutomaticSuccessHint": "All Tests will succeed if they roll equal to or lower than this number",
     "SETTINGS.AutomaticFailure": "Automatic Failure",
     "SETTINGS.AutomaticFailureHint": "All Tests will fail if they roll equal to or higher than this number",
+    "SETTINGS.UseRawAdvancements": "Use RAW Advancement Cost",
+    "SETTINGS.UseRawAdvancementsHint": "When checked, advancement cost will depend on currently owned advances. Otherwise it will depend on advance being bought.",
     "SETTINGS.CriticalsFumblesAllTests" : "Criticals and Fumbles on all Tests",
     "SETTINGS.CriticalsFumblesAllTestsHint" : "Rolling a double on any test results in an Astounding Success/Failure.",
     "SETTINGS.ExtendedTests" : "Extended Tests and 0 SL",


### PR DESCRIPTION
Per CRB, page 47:

![image](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/333af0c0-8642-45f3-8880-40ec9d887c95)  
![image](https://github.com/moo-man/WFRP4e-FoundryVTT/assets/11304207/1ff4bc83-8a51-462a-9a6e-b3a9959c1346)

So RAW advancement cost for Skills should go:  
10, 10, 10, 10, 10, 10, 15, 15...

Instead, it now goes:  
10, 10, 10, 10, 10, 15, 15, 15...


My proposed change makes the advancement cost work just like described in the official rulebook. However, because some people probably want the "unofficial cost", I made the setting, which by default is disabled (so by default, advances cost are counted as before – based on number of the advance being bought)

This is also supported by the table that shows first entry as `0 to 5`, as in "if you have between 0 and 5 advancements, next one costs 10". 
It makes no sense to "buy 0th advancement". And the 1st entry for that table was part of Errata.
