### PR TITLE
"Fix" scrollbars in Chrome 121+

### DIFF
--- a/static/css/wfrp4e.css
+++ b/static/css/wfrp4e.css
@@ -361,6 +361,13 @@
   }
 
 /* ==================== (F) SCROLLBAR ========================= */
+  /* Chrome 121 onward ignores ALL `-webkit-scrollbar-*` selectors if these two are set to anything at all */
+  /* Foundry's style sets these values so we need to force them unset */
+  :root {
+    scrollbar-color: unset !important;
+    scrollbar-width: unset !important;
+  }
+
   .app.window-app.sheet.wfrp4e.actor ::-webkit-scrollbar {
     width: 10px;
     box-shadow: inset 0 0 


### PR DESCRIPTION
"Fixed" the thicc blocky scrollbar (which isn't _that_ ugly when set to thin, but still worse than wfrp4e's one).

What happens is that Chrome from 121 onward will flat out **ignore** all `-webkit-scrollbar-*` selectors if either `scrollbar-color` or `scrollbar-width` is set. 

And unsetting it on specific selectors (like `.app.window-app.sheet.wfrp4e`) does not work, it must be removed from `:root` (where Foundry sets it).

However, this means that some other apps that do not use Warhammer's scrollbars will revert now to default look... and that would probably mean that either Warhammer scrollbar should be defined on `:root`, or the `scrollbar-color` and `scrollbar-width` would need to be set manually on specific apps.

One app I know reverts to default browser scrollbar which this change is File Picker. 

Tested on:
- Native Foundry
- Chrome
- Edge
- Opera GX


Yes, I hate `!important`.
Yes, I hate hacky ways of fighting with upstream CSS.
Yes, I hate when browsers do drastic changes like that...

"Source":
https://stackoverflow.com/a/77884484

PS: I do not expect you to outright merge this PR, mostly putting it here as an example and explanation, at least to the extend I understand the matter. Maybe there is better way that I yet fail to see. 