### PR TITLE
Fix unusable drop macro because it existed without permission

### DIFF
--- a/modules/hooks/hotbarDrop.js
+++ b/modules/hooks/hotbarDrop.js
@@ -1,42 +1,37 @@
-
-export default function() {
+export default function () {
   // Needs to be syncrhonous to return false
   Hooks.on("hotbarDrop", (bar, data, slot) => {
     if (data.type == "Item" || data.type == "Actor") {
-      handleMacroCreation(bar, data,slot)
+      handleMacroCreation(bar, data, slot)
       return false;
-    };
+    }
   })
 }
 
-async function handleMacroCreation(bar, data, slot)
-{
+async function handleMacroCreation(bar, data, slot) {
   let document = await fromUuid(data.uuid)
 
-  if (!document)  
+  if (!document)
     return
 
   let macro
-  if (document.documentName == "Item")
-  {
+  if (document.documentName == "Item") {
     if (document.type != "weapon" && document.type != "spell" && document.type != "prayer" && document.type != "trait" && document.type != "skill")
-    return
-  if (!document)
-    return false;
+      return
+    if (!document)
+      return false;
 
-  let command = `game.wfrp4e.utility.rollItemMacro("${document.name}", "${document.type}");`;
-  macro = game.macros.contents.find(m => (m.name === document.name) && (m.command === command));
-  if (!macro) {
-    macro = await Macro.create({
-      name: document.name,
-      type: "script",
-      img: document.img,
-      command: command
-    }, { displaySheet: false })
-  }
-  }
-  else if (document.documentName == "Actor")
-  {
+    let command = `game.wfrp4e.utility.rollItemMacro("${document.name}", "${document.type}");`;
+    macro = game.macros.contents.find(m => (m.name === document.name) && (m.command === command) && m.canExecute);
+    if (!macro) {
+      macro = await Macro.create({
+        name: document.name,
+        type: "script",
+        img: document.img,
+        command: command
+      }, {displaySheet: false})
+    }
+  } else if (document.documentName == "Actor") {
     let command = `Hotbar.toggleDocumentSheet("${document.uuid}")`
     macro = game.macros.contents.find(m => (m.name === document.name) && (m.command === command));
     if (!macro) {
@@ -45,10 +40,9 @@ async function handleMacroCreation(bar, data, slot)
         type: "script",
         img: document.prototypeToken.texture.src,
         command: command
-      }, { displaySheet: false })
+      }, {displaySheet: false})
     }
   }
 
   game.user.assignHotbarMacro(macro, slot);
 }
-


### PR DESCRIPTION
## Issue
When one player created a macro (dragging a `Hand Weapon`) from sheet to Hotbar, it would create macro as that player with only them having permission.

If then another player drags their `Hand Weapon`, they can see macro being put in Hotbar, but they do not have enough permissions to execute it.

## Solution
Simply adding ` && m.canExecute` to find conditions is more than enough. If player can execute a macro, it will be used, if not, new macro will be created

## Why not override permissions on creation?
This would also work, but I have several reasons to prefer the other solution:
1. I believe some people prefer having more control over their hotbar, especially choosing names, icons etc to their liking, so every user having their own macro that they are Owner of is in my opinion better. 
2. It would not work on already created macros without a migration. 

## Why so many changes in file?
Sorry, my auto formatter did this. I fired it because lines were not indented properly making code hard to read. 