### PR TITLE
Default value for hitLocation

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -172,7 +172,7 @@ export default class ActorWfrp4e extends WFRP4eDocumentMixin(Actor)
 
     if (dialogData.data.hitLoc)
     {
-      dialogData.fields.hitLocation = "roll", // Default a WS or BS test to have hit location;
+      dialogData.fields.hitLocation = dialogData.fields.hitLocation || "roll", // Default a WS or BS test to have hit location if not specified;
       dialogData.data.hitLocationTable = game.wfrp4e.tables.getHitLocTable(dialogData.data.targets[0]?.actor?.details?.hitLocationTable?.value || "hitloc");
     }
     else 


### PR DESCRIPTION
This PR allows setupSkill and setupCharacteristic to specify the default value of Hit Location. Previously it always showed "Roll".

My use case is my Endeavours module. Some require a weapon test that isn't an attack, so no need to roll location. Mainly useful to avoid confusing weapon critical/fumble messages.