### PR TITLE
Localized Gender for Name Generator

### DIFF
--- a/modules/apps/name-gen.js
+++ b/modules/apps/name-gen.js
@@ -318,9 +318,9 @@ export default class NameGenWfrp {
     if (options.gender)
       options.gender = options.gender.toLowerCase();
 
-    if (options.gender == game.i18n.localize("CHARGEN.Details.Male"))
+    if (options.gender == game.i18n.localize("CHARGEN.Details.Male").toLowerCase())
       options.gender = "male"
-    else if (options.gender == game.i18n.localize("CHARGEN.Details.Female"))
+    else if (options.gender == game.i18n.localize("CHARGEN.Details.Female").toLowerCase())
       options.gender = "female"
 
     // If gender not recognize, remove it (roll male or female names randomly)

--- a/modules/apps/name-gen.js
+++ b/modules/apps/name-gen.js
@@ -318,6 +318,11 @@ export default class NameGenWfrp {
     if (options.gender)
       options.gender = options.gender.toLowerCase();
 
+    if (options.gender == game.i18n.localize("CHARGEN.Details.Male"))
+      options.gender = "male"
+    else if (options.gender == game.i18n.localize("CHARGEN.Details.Female"))
+      options.gender = "female"
+
     // If gender not recognize, remove it (roll male or female names randomly)
     if (!["male", "female"].includes(options.gender))
       delete options.gender

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -635,6 +635,8 @@
     "CHARGEN.Details.LongTermAmbitions" : "Long Term Ambition",
     "CHARGEN.Details.Eyes" : "Eyes",
     "CHARGEN.Details.Hair" : "Hair",
+    "CHARGEN.Details.Male" : "male",
+    "CHARGEN.Details.Female" : "female",
 
     "CHARGEN.Message.Start" : "<p><b>{user}</b> has started character generation!</p>",
     "CHARGEN.Message.Rolled" : "<p>Rolled: <b>{rolled}</b>!</p>",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -635,8 +635,8 @@
     "CHARGEN.Details.LongTermAmbitions" : "Long Term Ambition",
     "CHARGEN.Details.Eyes" : "Eyes",
     "CHARGEN.Details.Hair" : "Hair",
-    "CHARGEN.Details.Male" : "male",
-    "CHARGEN.Details.Female" : "female",
+    "CHARGEN.Details.Male" : "Male",
+    "CHARGEN.Details.Female" : "Female",
 
     "CHARGEN.Message.Start" : "<p><b>{user}</b> has started character generation!</p>",
     "CHARGEN.Message.Rolled" : "<p>Rolled: <b>{rolled}</b>!</p>",


### PR DESCRIPTION
This allows the name generator to use localized genders. "male" and "female" can still be used.
Tested in the character creator and the name button of the NPC and Creature sheets.