### PR TITLE
AoE Fix

### DIFF
--- a/modules/system/aoe.js
+++ b/modules/system/aoe.js
@@ -36,7 +36,11 @@ export default class AbilityTemplate extends MeasuredTemplate {
     {
       if (aoeString.toLowerCase().includes(game.i18n.localize("AoE").toLowerCase()))
         aoeString = aoeString.substring(aoeString.indexOf("(")+1, aoeString.length-1)
-      
+
+      let test = game.messages.get(messageId).getTest();
+      if (!test.spell)
+	    diameter=false
+
       // Prepare template data
       const templateData = {
         t: "circle",


### PR DESCRIPTION
This is a fix for the AoE button in the overcast section of Spells/Prayers rolls.

The system always applied "diameter" in this AoE, now it will only apply diameter for spells.