### PR TITLE
Advantage cap update

### DIFF
--- a/modules/model/actor/components/status.js
+++ b/modules/model/actor/components/status.js
@@ -6,7 +6,8 @@ export class StandardStatusModel extends foundry.abstract.DataModel {
     static defineSchema() {
         let schema = {};
         schema.advantage = new fields.SchemaField({
-            value: new fields.NumberField({ initial: 0 })
+            value: new fields.NumberField({ initial: 0 }),
+            max: new fields.NumberField({ initial: game.settings.get("wfrp4e", "advantagemax") })
         });
 
         schema.wounds = new fields.SchemaField({

--- a/modules/model/actor/standard.js
+++ b/modules/model/actor/standard.js
@@ -128,7 +128,7 @@ export class StandardActorModel extends BaseActorModel {
                 this.status.advantage.value = Math.clamped(this.status.advantage.value, 0, this.status.advantage.max)
             }
             else
-                this.status.advantage.max = 10;
+                this.status.advantage.max = game.settings.get("wfrp4e", "advantagemax");
         }
     }
 
@@ -323,7 +323,7 @@ export class StandardActorModel extends BaseActorModel {
             if (game.settings.get("wfrp4e", "capAdvantageIB"))
                 maxAdvantage = this.characteristics.i.bonus;
             else
-                maxAdvantage = 10;
+                maxAdvantage = game.settings.get("wfrp4e", "advantagemax");
 
             if (data.system.status.advantage.value > maxAdvantage) {
                 data.system.status.advantage.value = this.status.advantage.max;


### PR DESCRIPTION
The Advantage Cap PR I sent earlier was made before the effect refactor update. This one works after the update.

Also, DataModel not having advantage.max creates some issues with the advantage token bar. It isn't recognized as a bar and thus it disappears if the token is updated in any way (changing the token's name, for example).