### PR TITLE
Allow compendium effects

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -1011,7 +1011,7 @@ export default class ActorWfrp4e extends WFRP4eDocumentMixin(Actor)
         {
             for (let uuid of effectUuids)
             {
-                let effect = fromUuidSync(uuid);
+                let effect = await fromUuid(uuid);
                 let message = game.messages.get(messageId);
                 await ActiveEffect.implementation.create(effect.convertToApplied(message?.getTest()), {parent: this, message : message?.id});
             }

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -216,15 +216,15 @@ export default class WFRP_Utility {
   static async findSkill(skillName) {
     let skill = await WFRP_Utility.findExactName(skillName, "skill");
 
-    if (!skill) {
-      skill = await WFRP_Utility.findBaseName(skillName, "skill");
-    }
+    if (skill)
+      return skill;
 
-    if (!skill) {
-      throw `"${game.i18n.format("ERROR.NoSkill", {skill: skillName})}"`;
-    }
+    skill = await WFRP_Utility.findBaseName(skillName, "skill");
 
-    return skill;
+    if (skill)
+      return skill;
+
+    throw `"${game.i18n.format("ERROR.NoSkill", {skill: skillName})}"`;
   }
 
   /**
@@ -245,15 +245,15 @@ export default class WFRP_Utility {
   static async findTalent(talentName) {
     let talent = await WFRP_Utility.findExactName(talentName, "talent");
 
-    if (!talent) {
-      talent = await WFRP_Utility.findBaseName(talentName, "talent");
-    }
+    if (talent)
+      return talent;
 
-    if (!talent) {
-      throw `"${game.i18n.format("ERROR.NoTalent", {talent: talentName})}"`;
-    }
+    talent = await WFRP_Utility.findBaseName(talentName, "talent");
 
-    return talent;
+    if (talent)
+      return talent;
+
+    throw `"${game.i18n.format("ERROR.NoTalent", {talent: talentName})}"`;
   }
 
   /**
@@ -358,16 +358,15 @@ export default class WFRP_Utility {
   static async findItem(itemName, itemType) {
     let item = await WFRP_Utility.findExactName(itemName, itemType)
 
-    if (!item) {
-      item = await WFRP_Utility.findBaseName(itemName, itemType)
-    }
+    if (item)
+      return item;
 
-    if (!item) {
-      console.error("Cannot find " + itemName)
-      return null;
-    }
+    item = await WFRP_Utility.findBaseName(itemName, itemType)
 
-    return item;
+    if (item)
+      return item;
+
+    console.error("Cannot find " + itemName);
   }
 
 

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -214,12 +214,17 @@ export default class WFRP_Utility {
    * @param {String} skillName skill name to be searched for
    */
   static async findSkill(skillName) {
-    let skill = await WFRP_Utility.findBaseName(skillName, "skill")
-    if (!skill)
-    {
-      throw `"${game.i18n.format("ERROR.NoSkill", {skill: skillName})}"`
+    let skill = await WFRP_Utility.findExactName(skillName, "skill");
+
+    if (!skill) {
+      skill = await WFRP_Utility.findBaseName(skillName, "skill");
     }
-    return skill
+
+    if (!skill) {
+      throw `"${game.i18n.format("ERROR.NoSkill", {skill: skillName})}"`;
+    }
+
+    return skill;
   }
 
   /**
@@ -238,12 +243,14 @@ export default class WFRP_Utility {
    * @param {String} talentName talent name to be searched for
    */
   static async findTalent(talentName) {
-    let talent = await WFRP_Utility.findExactName(talentName, "talent")
+    let talent = await WFRP_Utility.findExactName(talentName, "talent");
 
     if (!talent) {
-      talent = await WFRP_Utility.findBaseName(talentName, "talent")
-    } else if (!talent){
-      throw `"${game.i18n.format("ERROR.NoTalent", {talent: talentName})}"`
+      talent = await WFRP_Utility.findBaseName(talentName, "talent");
+    }
+
+    if (!talent) {
+      throw `"${game.i18n.format("ERROR.NoTalent", {talent: talentName})}"`;
     }
 
     return talent;
@@ -349,15 +356,18 @@ export default class WFRP_Utility {
    * @param {String|Array} itemType   Item's type (armour, weapon, etc.)
    */
   static async findItem(itemName, itemType) {
-    let item = await WFRP_Utility.findBaseName(itemName, itemType)
-    if (item)
-    {
-      return item;
+    let item = await WFRP_Utility.findExactName(itemName, itemType)
+
+    if (!item) {
+      item = await WFRP_Utility.findBaseName(itemName, itemType)
     }
-    else 
-    {
+
+    if (!item) {
       console.error("Cannot find " + itemName)
+      return null;
     }
+
+    return item;
   }
 
 


### PR DESCRIPTION
Minor change I need for scrolls to work with spell's effects. 

Since scrolls are not spells and only mimic them, for Chat Cards to know what effects to trigger I need them to point to Compendium UUID.

This PR changes `Actor.applyEffect` method so it can load any UUID with `await fromUuid()` instead `fromUuidSync()`.

This is completely safe since `Actor.applyEffect` is `async` already, so there is no reason to use `fromUuidSync()` anyway. 