### PR TITLE
Fix non-damage opposed tests undefined breakdown error

### DIFF
--- a/modules/system/opposed-test.js
+++ b/modules/system/opposed-test.js
@@ -179,7 +179,9 @@ export default class OpposedTest {
           this.findHitLocation();
         }
 
-        opposeResult.breakdown.formatted = this.formatBreakdown();
+        if (opposeResult.breakdown) {
+          opposeResult.breakdown.formatted = this.formatBreakdown();
+        }
 
         try // SOUND
         {


### PR DESCRIPTION
Fixes non-damage Opposed Tests (for example Opposed Strength Test or Opposed Perception/Stealth Test) having undefined damage breakdown, which caused Type Error. 

  - Fixes #2006