### PR TITLE
Allow talent replacement and predefined career table

### DIFF
--- a/modules/apps/chargen/career.js
+++ b/modules/apps/chargen/career.js
@@ -125,8 +125,11 @@ export class CareerStage extends ChargenStage {
   async addCareerChoice(number = 1) {
     let rollSpecies = this.data.species;
 
+    // If subspecies has defined specific table, and it's found, use that
+    if (this.data.subspecies && game.wfrp4e.tables.findTable("career", game.wfrp4e.config.subspecies[this.data.species][this.data.subspecies]?.careerTable))
+      rollSpecies = game.wfrp4e.config.subspecies[this.data.species][this.data.subspecies]?.careerTable;
     // If subspecies table is found, use that
-    if (this.data.subspecies && game.wfrp4e.tables.findTable("career", rollSpecies + "-" + this.data.subspecies))
+    else if (this.data.subspecies && game.wfrp4e.tables.findTable("career", rollSpecies + "-" + this.data.subspecies))
       rollSpecies += "-" + this.data.subspecies;
     
 

--- a/modules/apps/chargen/career.js
+++ b/modules/apps/chargen/career.js
@@ -126,7 +126,8 @@ export class CareerStage extends ChargenStage {
     let rollSpecies = this.data.species;
 
     // If subspecies has defined specific table, and it's found, use that
-    if (this.data.subspecies && game.wfrp4e.tables.findTable("career", game.wfrp4e.config.subspecies[this.data.species][this.data.subspecies]?.careerTable))
+    let subspeciesCareerTable = this.data.subspecies && game.wfrp4e.config.subspecies[this.data.species][this.data.subspecies]?.careerTable || null;
+    if (subspeciesCareerTable && game.wfrp4e.tables.findTable("career", subspeciesCareerTable))
       rollSpecies = game.wfrp4e.config.subspecies[this.data.species][this.data.subspecies]?.careerTable;
     // If subspecies table is found, use that
     else if (this.data.subspecies && game.wfrp4e.tables.findTable("career", rollSpecies + "-" + this.data.subspecies))

--- a/modules/system/config-wfrp4e.js
+++ b/modules/system/config-wfrp4e.js
@@ -921,6 +921,7 @@ WFRP4E.speciesCharacteristics = {}
 WFRP4E.speciesSkills = {}
 WFRP4E.speciesTalents = {}
 WFRP4E.speciesRandomTalents = {}
+WFRP4E.speciesTalentReplacement = {}
 WFRP4E.speciesMovement = {}
 WFRP4E.speciesFate = {}
 WFRP4E.speciesRes = {}

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -108,11 +108,12 @@ export default class WFRP_Utility {
 
 
   static speciesSkillsTalents(species, subspecies) {
-    let skills, talents, randomTalents;
+    let skills, talents, randomTalents, talentReplacement;
 
     skills = game.wfrp4e.config.speciesSkills[species];
     talents = game.wfrp4e.config.speciesTalents[species];
     randomTalents = game.wfrp4e.config.speciesRandomTalents[species] || {talents: 0};
+    talentReplacement = game.wfrp4e.config.speciesTalentReplacement[species] || {};
 
     if (subspecies && game.wfrp4e.config.subspecies[species][subspecies].skills)
       skills = game.wfrp4e.config.subspecies[species][subspecies].skills;
@@ -123,7 +124,10 @@ export default class WFRP_Utility {
     if (subspecies && game.wfrp4e.config.subspecies[species][subspecies].randomTalents)
       randomTalents = game.wfrp4e.config.subspecies[species][subspecies].randomTalents || {talents: 0};
 
-    return { skills, talents, randomTalents };
+    if (subspecies && game.wfrp4e.config.subspecies[species][subspecies].talentReplacement)
+      talentReplacement = game.wfrp4e.config.subspecies[species][subspecies].talentReplacement || {};
+
+    return { skills, talents, randomTalents, talentReplacement };
   }
 
   /**

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -643,6 +643,8 @@
     "CHARGEN.SkillsTalents.RandomTalents" : "Roll {count} Random Talents",
     "CHARGEN.SkillsTalents.CareerSkills" : "Allocate 40 Points to Career Skills ({points} left)",
     "CHARGEN.SkillsTalents.CareerTalent" : "Choose 1 Career Talent",
+    "CHARGEN.SkillsTalents.ReplaceTalentDialog.Title" : "Replace Talent",
+    "CHARGEN.SkillsTalents.ReplaceTalentDialog.Content" : "<p>Do you want to replace {talent} with {replacement}?</p>",
 
     "CHARGEN.RerollDuplicateTalent" : "You may reroll duplicate talents",
     "CHARGEN.AdditionalRandomTalent" : "Additional Random Talent",
@@ -673,6 +675,7 @@
     "CHARGEN.Message.SwappedCharacteristics" : "<p>Swapped {ch1} with {ch2}</p>",
     "CHARGEN.Message.AllocateCharacteristics" : "<p>Started Allocating Characteristics</p>",
     "CHARGEN.Message.Created" : "<p><b>{name}</b> created!",
+    "CHARGEN.Message.ReplacedTalent" : "<p>Replaced <b>{talent}</b> with <b>{replacement}</b>!</p>",
 
     "CHARGEN.NoGMWarning" : "In order to create a character either a GM must be logged in or players be given the 'Create New Actors' Permission",
     "CHARGEN.UseExistingData" : "Use Existing Data",


### PR DESCRIPTION
Two changes suggestions in order to make Sea of Claws Chargen work better.

1. Allows all three Norse subspecies to share a rollable table, as defined in their config
2. Allows species and subspecies to have optional Talent replacement 

**SoC, page 56 (bottom left):**
> A Skaeling Character who generates the Pure Soul Talent as a Random Talent may take the Mark of Khorne instead.