### PR TITLE
Allow area effects to be loaded async so scrolls can use them

### DIFF
--- a/modules/actor/sheet/actor-sheet.js
+++ b/modules/actor/sheet/actor-sheet.js
@@ -1731,7 +1731,8 @@ export default class ActorSheetWfrp4e extends WFRP4eSheetMixin(ActorSheet) {
     {
       return
     }
-    AbilityTemplate.fromEffect(effectUuid).drawPreview(event);
+    let template = await AbilityTemplate.fromEffect(effectUuid)
+    await template.drawPreview(event);
   }
 
 

--- a/modules/hooks/ready.js
+++ b/modules/hooks/ready.js
@@ -26,10 +26,10 @@ export default function () {
         return OpposedTest.recreate(getProperty(this, "flags.wfrp4e.opposeTestData"))
     }
 
-    CONFIG.MeasuredTemplate.documentClass.prototype.areaEffect = function () {
+    CONFIG.MeasuredTemplate.documentClass.prototype.areaEffect = async function () {
       if (this.getFlag("wfrp4e", "effectUuid"))
       {
-        let effect = fromUuidSync(this.getFlag("wfrp4e", "effectUuid"))
+        let effect = await fromUuid(this.getFlag("wfrp4e", "effectUuid"))
         if (effect && effect.applicationData.type != "aura")
         {
           effect.updateSource({"flags.wfrp4e.fromMessage" : this.getFlag("wfrp4e", "messageId")})

--- a/modules/system/aoe.js
+++ b/modules/system/aoe.js
@@ -63,9 +63,9 @@ export default class AbilityTemplate extends MeasuredTemplate {
       return new this(template);
     }
 
-  static fromEffect(effectUuid, messageId, radius) {
+  static async fromEffect(effectUuid, messageId, radius) {
 
-    let effect = fromUuidSync(effectUuid);
+    let effect = await fromUuid(effectUuid);
     // Sometimes, the radius needs to reference the test (usually overcasting)
     setProperty(effect, "flags.wfrp4e.sourceTest",  game.messages.get(messageId)?.getTest());
     radius = radius || effect.radius; 

--- a/modules/system/area-helpers.js
+++ b/modules/system/area-helpers.js
@@ -91,7 +91,7 @@ export default class AreaHelpers
                 let inTemplate = this.isInTemplate(token.object.center, template)
                 if (inTemplate && !existingEffect)
                 {
-                    let effect = template.document.areaEffect() || template.auraEffect
+                    let effect = await template.document.areaEffect() || template.auraEffect
                     if (effect && template.auraEffect?.actor != token.actor) // Specifically don't apply auras to self
                     {
                         // if template was placed from a test

--- a/modules/system/chat-wfrp4e.js
+++ b/modules/system/chat-wfrp4e.js
@@ -633,7 +633,8 @@ export default class ChatWFRP {
     {
       return
     }
-    AOETemplate.fromEffect(effectUuid, messageId, radius).drawPreview(event);
+    let template = await AOETemplate.fromEffect(effectUuid, messageId, radius);
+    await template.drawPreview(event);
   }
 
   static _onOpposedImgClick(event) {


### PR DESCRIPTION
My magic scrolls cast spells by using their world or compendium UUID as reference, so I would need all instances of where their effects are loaded to be `await fromUuid`. 

Fortunately this fix for area is not disruptive as most changes were already within an async function, or were an endpoint where it doesn't matter. 