### PR TITLE
Generic aspect usage and sheet trigger

### DIFF
--- a/modules/actor/sheet/actor-sheet.js
+++ b/modules/actor/sheet/actor-sheet.js
@@ -709,6 +709,7 @@ export default class ActorSheetWfrp4e extends WFRP4eSheetMixin(ActorSheet) {
     html.on('click', '.diagnosed', this._onDiagnoseToggle.bind(this));
     html.on('click', '.open-vehicle', this._onVehicleClick.bind(this));
     html.on('click', '.remove-vehicle', this._onVehicleRemove.bind(this));
+    html.on('click', '.aspect-use', this._onAspectClick.bind(this))
 
     
     html.on("click", ".trigger-script", this._onTriggerScript.bind(this));
@@ -1692,6 +1693,16 @@ export default class ActorSheetWfrp4e extends WFRP4eSheetMixin(ActorSheet) {
   {
     await this.actor.system.vehicle.update({"system.passengers.list" : this.actor.system.vehicle?.system.passengers.remove(this.actor.id)});
     this.render(true);
+  }
+
+  async _onAspectClick(ev)
+  {
+    let itemId = this._getId(ev);
+    let aspect = this.actor.items.get(itemId);
+    if (aspect && aspect.system.usable)
+    {
+      aspect.system.use();
+    }
   }
 
   async _onApplyTargetEffect(event) {

--- a/modules/hooks/init.js
+++ b/modules/hooks/init.js
@@ -774,5 +774,10 @@ export default function() {
 
     // Keep a list of actors that need to prepareData after 'ready' (generally those that rely on other actor data - passengers/mounts)
     game.wfrp4e.postReadyPrepare = [];
+
+
+    loadTemplates({
+      aspectDetails: 'systems/wfrp4e/templates/items/partials/item-aspect-details.hbs'
+    });
   });
 }

--- a/modules/model/item/generic.js
+++ b/modules/model/item/generic.js
@@ -35,4 +35,52 @@ export class GenericAspectModel extends BaseItemModel
     {
         return this.constructor.plural;
     }
+
+    /**
+     * Whether the Aspect can be "used" or not. Usage may – depending on Aspect – mean Rolling, initiating a Test,
+     * or doing something else entirely.
+     *
+     * @returns {boolean}
+     * @public
+     */
+    get usable()
+    {
+        return false;
+    }
+
+    /**
+     * Method which serves as a public wrapper for _performUsage() method, while also calling a pre-use and post-use hook.
+     *
+     * @param {{}} options
+     *
+     * @returns {Promise<TestWFRP|Roll|null>}
+     * @public
+     */
+    async use(options = {})
+    {
+        if (!this.usable)
+            return null;
+
+        if (!Hooks.call('wfrp4e:beforeUseAspect', this.parent, options))
+            return null;
+
+        const result = await this._performUsage(options);
+
+        Hooks.callAll('wfrp4e:afterUseAspect', this.parent, result, options);
+
+        return result;
+    }
+
+    /**
+     * Method which should implement entire logic behind "using an Aspect" such as rolling or initiating a Test.
+     *
+     * Should return either object of TestWFRP class, object of Roll class or null if Aspect is not rollable.
+     *
+     * @returns {Promise<TestWFRP|Roll|null>}
+     * @protected
+     */
+    async _performUsage({} = {})
+    {
+        return null;
+    }
 }

--- a/modules/model/item/generic.js
+++ b/modules/model/item/generic.js
@@ -17,11 +17,15 @@ export class GenericAspectModel extends BaseItemModel
     {
         return this.constructor.label;
     }
-
     
     get pluralLabel() 
     {
         return this.constructor.plural;
+    }
+
+    get detailsPartial()
+    {
+        return 'aspectDetails';
     }
 
     /**

--- a/modules/model/item/generic.js
+++ b/modules/model/item/generic.js
@@ -8,18 +8,6 @@ export class GenericAspectModel extends BaseItemModel
     static label = "Aspect"
     static plural = "Aspects"
 
-    static defineSchema() 
-    {
-        let schema = super.defineSchema();
-
-        schema.use = new fields.SchemaField({
-            formula : new fields.StringField({initial : ""}),
-            skill : new fields.StringField({initial : ""})
-        })
-
-        return schema;
-    }
-
     get placement() 
     {
         return this.constructor.placement;

--- a/static/templates/items/item-aspect-sheet.hbs
+++ b/static/templates/items/item-aspect-sheet.hbs
@@ -14,18 +14,7 @@
     {{> systems/wfrp4e/templates/items/item-description.hbs}}
 
     <div class="tab details" data-tab="details">
-      <div class="form-group">
-        <label class="label-text">{{localize "Formula"}}</label>
-        <div class="input-box">
-          <input class="input-text" type="text" name="system.use.formula" value="{{system.use.formula}}" />
-        </div>
-      </div>
-      <div class="form-group">
-        <label class="label-text">{{localize "Skill"}}</label>
-        <div class="input-box">
-          <input class="input-text" type="text" name="system.use.skill" value="{{system.use.skill}}" />
-        </div>
-      </div>
+        {{> (lookup item.system 'detailsPartial') }}
     </div>
     {{> systems/wfrp4e/templates/items/item-effects.hbs}}
 

--- a/static/templates/items/item-aspect-sheet.hbs
+++ b/static/templates/items/item-aspect-sheet.hbs
@@ -1,5 +1,5 @@
 <form class="wfrp4e item-sheet {{cssClass}}" autocomplete="off">
-  {{> systems/wfrp4e/templates/items/item-header.hbs category=system.label}}
+  {{> systems/wfrp4e/templates/items/item-header.hbs category=item.system.label}}
 
   <nav class="sheet-tabs tabs" data-tab-container="primary">
     <a class="item active" data-tab="description">{{localize "Description"}}</a>

--- a/static/templates/partials/aspect-list.hbs
+++ b/static/templates/partials/aspect-list.hbs
@@ -3,11 +3,11 @@
   <div id="trait-name">{{localize @key}}</div>
   <div class="item-controls"></div>
 </div>
-<ol class="inventory-list trait-list save-scroll">
+<ol class="inventory-list trait-list aspect-list save-scroll">
   {{#each this as |item i|}}
   <li class="item" data-id="{{item.id}}">
     <div class="content">
-      <div class="item-name">
+      <div class="item-name aspect-use">
         <div class="image" style="background-image: url({{item.img}})"></div>
         <a class="name">{{item.name}}</a>
       </div>


### PR DESCRIPTION
This PR allows aspects to be triggered by the system, while letting modules define the implementation. 

On the same note, I am unsure if the following schema even belongs to the Generic Aspect Model, since the model itself is abstract and the children should define their own schema (and may not even use this one)

```js
schema.use = new fields.SchemaField({
  formula : new fields.StringField({initial : ""}),
  skill : new fields.StringField({initial : ""})
})
```