### PR TITLE
Load travel data files with .json extension only

### DIFF
--- a/modules/apps/travel-distance-wfrp4e.js
+++ b/modules/apps/travel-distance-wfrp4e.js
@@ -16,7 +16,7 @@ export default class TravelDistanceWfrp4e {
 
         for (var file of resp.files) {
           try {
-            if (!file.includes(".json"))
+            if (!file.endsWith(".json"))
               continue
             let filename = file.substring(file.lastIndexOf("/") + 1, file.indexOf(".json"));
 


### PR DESCRIPTION
Modify `loadTravelData()` function to load `.json` files only, preventing errors with `.json.gz` files stored for nginx static compression.