### PR TITLE
mooHomebrewItemChanges fixes

### DIFF
--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -1203,7 +1203,7 @@ export default class ActorWFRP4e extends WarhammerActor
   async applyTerror(value, name = undefined) {
     value = value || 1
     let terror = foundry.utils.duplicate(game.wfrp4e.config.systemItems.terror)
-    terror.flags.wfrp4e.terrorValue = value
+    foundry.utils.setProperty(terror, "flags.wfrp4e.terrorValue", value);
     let scripts = new ActiveEffectWFRP4e(terror, {parent: this}).scripts;
     for (let s of scripts) {
       await s.execute({ actor: this });

--- a/modules/actor/actor-wfrp4e.js
+++ b/modules/actor/actor-wfrp4e.js
@@ -85,7 +85,15 @@ export default class ActorWFRP4e extends WarhammerActor
     }
   }
 
-  
+  _onUpdateDescendantDocuments(...args)
+  {
+      super._onUpdateDescendantDocuments(...args);
+      // If an owned item (trait specifically) is disabled, check auras
+      if (args[1] == "items" && args[3].some(update => (hasProperty(update, "system.disabled"))))
+      {
+          TokenHelpers.updateAuras(this.getActiveTokens()[0]?.document);
+      }
+  }  
   
   /**
    * @override 

--- a/modules/apps/chargen/char-gen.js
+++ b/modules/apps/chargen/char-gen.js
@@ -376,7 +376,7 @@ export default class CharGenWfrp4e extends FormApplication {
         // Must create items separately so preCreate scripts run
         let actorItems = this.actor.items;
         this.actor.items = [];
-        let document = await Actor.create(this.actor);
+        let document = await Actor.create(this.actor, {skipItems : true});
         await document.createEmbeddedDocuments("Item", actorItems)
         document.sheet.render(true);
         localStorage.removeItem("wfrp4e-chargen")

--- a/modules/apps/roll-dialog/attack-dialog.js
+++ b/modules/apps/roll-dialog/attack-dialog.js
@@ -181,7 +181,7 @@ export default class AttackDialog extends SkillDialog
         }
     }
 
-    async _onInputChanged(ev) 
+    async _onFieldChange(ev) 
     {
       if (ev.currentTarget.name == "charging")
       {
@@ -204,6 +204,6 @@ export default class AttackDialog extends SkillDialog
           this.flags.charging = ev.currentTarget.checked;
         }
       }
-        super._onInputChanged(ev)
+        super._onFieldChange(ev)
     }
 }

--- a/modules/hooks/ready.js
+++ b/modules/hooks/ready.js
@@ -55,7 +55,7 @@ export default function () {
     let needMigration = foundry.utils.isNewerVersion(MIGRATION_VERSION, game.settings.get("wfrp4e", "systemMigrationVersion"))
     if (needMigration && game.user.isGM) {
       ChatMessage.create({content: `<h1>The Effect Refactor</h1>
-        <p>WFRP4e Version 7.1.0 has entirely reworked how Active Effects are implemented, and all the automation you're used to has been vastly improved! However, existing Actors need to be updated manually. The automatic migration handles the basics, but won't update your Actors with the new Items.</p>
+        <p>If you are updating from pre-WFRP4e Version 7.1.0, Active Effect scripting has been greatly reworked, and all the automation you're used to has been vastly improved! However, existing Actors need to be updated manually. The automatic migration handles the basics, but won't update your Actors with the new Items.</p>
         
         <p><strong>Minimum</strong>: Make sure your preimum modules are updated! Delete module content you've imported in your world, then replace every Talent on your unique Actors, like Player Characters or other ones you've created yourself. Reimport the module content you wish to use, which should be updated with the latest Items.</p>
         

--- a/modules/model/item/armour.js
+++ b/modules/model/item/armour.js
@@ -190,7 +190,7 @@ export class ArmourModel extends PropertiesMixin(EquippableItemModel) {
     }
 
     if (data.worn?.value) {
-      data.equipped.value = data.worn.value;
+      foundry.utils.setProperty(data, "equipped.value", data.worn.value);
     }
   }
 

--- a/modules/model/item/skill.js
+++ b/modules/model/item/skill.js
@@ -54,10 +54,10 @@ export class SkillModel extends BaseItemModel {
       }
     
 
-    async _preCreate(data, options, user) {
-        await super._preCreate(data, options, user);
-
-        if (this.parent.isOwned && this.grouped.value == "isSpec" && data.name) {
+    async _preUpdate(data, options, user) {
+        await super._preUpdate(data, options, user);
+        let diff = foundry.utils.diffObject(data, this.parent);
+        if (this.parent.isOwned && this.grouped.value == "isSpec" && diff.name) {
             this._handleSkillNameChange(data.name)
         }
     }

--- a/modules/model/item/weapon.js
+++ b/modules/model/item/weapon.js
@@ -346,7 +346,7 @@ export class WeaponModel extends PropertiesMixin(EquippableItemModel) {
         if (game.settings.get("wfrp4e", "mooRangeBands")) {
             game.wfrp4e.utility.logHomebrew("mooRangeBands")
             if (!this.parent.getFlag("wfrp4e", "optimalRange"))
-                game.wfrp4e.utility.log("Warning: No Optimal Range set for " + this.name)
+                warhammer.utility.log("Warning: No Optimal Range set for " + this.name)
 
             rangeBands[`${game.i18n.localize("Point Blank")}`].modifier = this.#optimalDifference(game.i18n.localize("Point Blank")) * -20 + 20
             delete rangeBands[`${game.i18n.localize("Point Blank")}`].difficulty

--- a/modules/system/audio-wfrp4e.js
+++ b/modules/system/audio-wfrp4e.js
@@ -8,7 +8,7 @@ export default class WFRP_Audio {
         console.warn("wfrp4e | Sound file not found for context: %o", context)
         return
       }
-      game.wfrp4e.utility.log(`wfrp4e | Playing Sound: ${sound.file}`)
+      warhammer.utility.log(`wfrp4e | Playing Sound: ${sound.file}`)
       AudioHelper.play({ src: sound.file }, sound.global)
     })
     

--- a/modules/system/config-wfrp4e.js
+++ b/modules/system/config-wfrp4e.js
@@ -2226,10 +2226,12 @@ WFRP4E.PrepareSystemItems = function() {
             id: "dead",
             statuses: ["dead"],
             name: "WFRP4E.ConditionName.Dead",
-            condition : {
-                value : null,
-                numbered: false
-            },
+            system : {
+                condition : {
+                    value : null,
+                    numbered: false
+                },
+            }
         }
     ]
 }

--- a/modules/system/migrations.js
+++ b/modules/system/migrations.js
@@ -306,7 +306,7 @@ export default class Migration {
     }
     effectModels = effectModels.filter(e => !foundry.utils.isEmpty(e));
 
-    await this.actor.updateEmbeddedDocuments("ActiveEffect", effectModels);
+    await actor.updateEmbeddedDocuments("ActiveEffect", effectModels);
   }
 
   static migrateJournalData(journal)

--- a/modules/system/migrations.js
+++ b/modules/system/migrations.js
@@ -537,7 +537,7 @@ export default class Migration {
 
   static removeLoreEffects(docData)
   {
-    let loreEffects = (docData.effects || []).filter(i => i.flags.wfrp4e?.lore)
+    let loreEffects = (docData.effects || []).filter(i => i.flags?.wfrp4e?.lore)
     if (loreEffects.length)
     {
       warhammer.utility.log("Removing lore effects for " + docData.name, true, loreEffects);

--- a/modules/system/moo-house.js
+++ b/modules/system/moo-house.js
@@ -79,7 +79,8 @@ export default function () {
           let item = await fromUuid(id)
           if (item)
           {
-            item.updateSource(data)
+            const diff = item.updateSource(data)
+            console.log({diff})
             game.wfrp4e.utility.logHomebrew("mooHomebrewItemChanges: " + id + ` (${item.name})`)
           }
         }

--- a/modules/system/moo-house.js
+++ b/modules/system/moo-house.js
@@ -84,10 +84,10 @@ export default function () {
           }
         }
         catch {
-          game.wfrp4e.utility.log("Could not find item " + id)
+          warhammer.utility.log("Could not find item " + id)
         }
       }
-      game.wfrp4e.utility.log("Compendium changes will revert if homebrew items is deactivated and the game is refreshed")
+      warhammer.utility.log("Compendium changes will revert if homebrew items is deactivated and the game is refreshed")
     })
     if (game.user.isGM)
     {

--- a/modules/system/rolls/test-wfrp4e.js
+++ b/modules/system/rolls/test-wfrp4e.js
@@ -793,7 +793,7 @@ export default class TestWFRP extends WarhammerTestBase{
     if (game.settings.get("wfrp4e", "manualChatCards") && !this.message)
       this.result.roll = this.result.SL = null;
 
-    if (game.modules.get("dice-so-nice") && game.modules.get("dice-so-nice").active && chatOptions.sound?.includes("dice"))
+    if (game.modules.get("dice-so-nice") && game.modules.get("dice-so-nice").active && messageData.sound?.includes("dice"))
       messageData.sound = undefined;
 
     let templateData = {

--- a/modules/system/rolls/test-wfrp4e.js
+++ b/modules/system/rolls/test-wfrp4e.js
@@ -430,7 +430,7 @@ export default class TestWFRP extends WarhammerTestBase{
         }
       }
       catch (e) {
-        game.wfrp4e.utility.log("Error appyling homebrew mooCriticalMitigation: " + e)
+        warhammer.utility.log("Error appyling homebrew mooCriticalMitigation: " + e)
       }
     }
     //@/HOUSE

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -878,7 +878,7 @@ export default class WFRP_Utility {
   }
   
   static logHomebrew(message) {
-    this.log("Applying Homebrew Rule: " + message, true)
+    warhammer.utility.log("Applying Homebrew Rule: " + message, true)
   }
 
   static extractLinkLabel(link)

--- a/static/moo/items.json
+++ b/static/moo/items.json
@@ -1,6 +1,6 @@
 {
-    "Compendium.wfrp4e-core.talents.1IZWRr7BYOIcqPlQ": {
-        "data": {
+    "Compendium.wfrp4e-core.items.1IZWRr7BYOIcqPlQ": {
+        "system": {
             "description": {
                 "value": "<p>Your experience, talent or training lets you more safely manipulate the Winds of Magic. Whenever you roll on a miscast table as a result of a successful Channelling Test, you may apply a -10 modifier to the table result for each level of this talent. If the result is 0 or below, either roll on the lesser miscat table with the same modifier, or the miscast is nuillifed if it was a Minor Miscast.</p>"
             }
@@ -31,7 +31,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.ywpZfCr5SxGBfDbV": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Chamon)",
                 "Intuition",
@@ -46,7 +46,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.zqJCLbUwhl4ttrw2": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Shyish)",
                 "Dodge",
@@ -73,7 +73,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.zuST5RpmAC0g9jGS": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Shyish)",
                 "Dodge",
@@ -98,7 +98,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.70eb3fw0COeid5GK": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Azyr)",
                 "Intuition",
@@ -113,7 +113,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.IFVfg9zvOvRH5arR": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Hysh)",
                 "Entertain (Singing)",
@@ -128,7 +128,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.IHC39zVZ5LDXGysD": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Aqshy)",
                 "Cool",
@@ -146,7 +146,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.04opjbLrU6yL4EUx": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Azyr)",
                 "Intuition",
@@ -172,8 +172,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-archives1.archives1-items.qBqfo35CFyWAAAnX": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.qBqfo35CFyWAAAnX": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -211,8 +211,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.ByHt0vTWRIuHS2r8": {
-        "data": {
+    "Compendium.wfrp4e-core.items.ByHt0vTWRIuHS2r8": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -245,8 +245,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.qim3Ad0ldTS9mXDj": {
-        "data": {
+    "Compendium.wfrp4e-core.items.qim3Ad0ldTS9mXDj": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -261,8 +261,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.kFROfGFdExfyJTg9": {
-        "data": {
+    "Compendium.wfrp4e-core.items.kFROfGFdExfyJTg9": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -278,8 +278,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.X8WFQf0HB9yXKjdD": {
-        "data": {
+    "Compendium.wfrp4e-core.items.X8WFQf0HB9yXKjdD": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -305,7 +305,7 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.U94l3IDj3xfIc78i": {
+    "Compendium.wfrp4e-core.items.U94l3IDj3xfIc78i": {
         "flags": {
             "wfrp4e": {
                 "optimalRange": "normal"
@@ -313,7 +313,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.OBLt5TXumqhXpTJB": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Shyish)",
                 "Dodge",
@@ -327,8 +327,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.xdAP96GGDb87m0Pr": {
-        "data": {
+    "Compendium.wfrp4e-core.items.xdAP96GGDb87m0Pr": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -344,8 +344,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.HDQVaCTpIy2PBdYu": {
-        "data": {
+    "Compendium.wfrp4e-core.items.HDQVaCTpIy2PBdYu": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -361,8 +361,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-archives1.archives1-items.nyUbN0JaeXNQUbUT": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.nyUbN0JaeXNQUbUT": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -394,8 +394,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.ksRqHiMVpIL07Ij1": {
-        "data": {
+    "Compendium.wfrp4e-core.items.ksRqHiMVpIL07Ij1": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -419,8 +419,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.M71CyisSXU0I7V1S": {
-        "data": {
+    "Compendium.wfrp4e-core.items.M71CyisSXU0I7V1S": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -435,8 +435,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.ddXgrDWZXSM3nXaf": {
-        "data": {
+    "Compendium.wfrp4e-core.items.ddXgrDWZXSM3nXaf": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -451,8 +451,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-archives1.archives1-items.XurSURwIt8pnoOlJ": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.XurSURwIt8pnoOlJ": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -504,7 +504,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.Gx1WB8mmt8IAI1YR": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ghyran)",
                 "Dodge",
@@ -518,8 +518,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-archives1.archives1-items.aQE698skxSqkrdmO": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.aQE698skxSqkrdmO": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -551,8 +551,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-archives1.archives1-items.BIW1jibsj1mZTKq0": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.BIW1jibsj1mZTKq0": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -584,8 +584,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-archives1.archives1-items.yaQBcwPMyEyP7H2f": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.yaQBcwPMyEyP7H2f": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -621,8 +621,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.NQ4OVp1ZfinJ7lQH": {
-        "data": {
+    "Compendium.wfrp4e-core.items.NQ4OVp1ZfinJ7lQH": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -646,8 +646,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.2mE771fGEEB38OqG": {
-        "data": {
+    "Compendium.wfrp4e-core.items.2mE771fGEEB38OqG": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -671,8 +671,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-archives1.archives1-items.LIzUGidgb1mkXcZB": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.LIzUGidgb1mkXcZB": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -684,16 +684,16 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.talents.0pXva9EODy9bngQX": {
-        "data": {
+    "Compendium.wfrp4e-core.items.0pXva9EODy9bngQX": {
+        "system": {
             "description": {
                 "value": "<p>You have trained how to make false attacks in close combat to fool your opponent. You may now make a Feint for your Action against any opponent using a weapon. This is resolved with an Unopposed Melee (Fencing) Test against a creature. If you succeed, and you attack the same opponent before the end of the next Round, you may add the SL of your Feint to your attack roll.</p>"
             }
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.uSxXVJogASbJ62hl": {
-        "data": {
+    "Compendium.wfrp4e-core.items.uSxXVJogASbJ62hl": {
+        "system": {
             "damage": {
                 "value": "SB+2"
             },
@@ -720,8 +720,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.QnFLWJmz2DN76Dx5": {
-        "data": {
+    "Compendium.wfrp4e-core.items.QnFLWJmz2DN76Dx5": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -741,7 +741,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.pytEYItxG2wwp9j6": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ulgu)",
                 "Intuition",
@@ -766,7 +766,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.htaOTnb6T6PpPxUz": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ulgu)",
                 "Intuition",
@@ -792,8 +792,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.CXg7XOFJwu4LZ9LM": {
-        "data": {
+    "Compendium.wfrp4e-core.items.CXg7XOFJwu4LZ9LM": {
+        "system": {
             "reach": {
                 "value": "vLong"
             },
@@ -815,8 +815,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.zuFTVmBtN51K94Xy": {
-        "data": {
+    "Compendium.wfrp4e-core.items.zuFTVmBtN51K94Xy": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -852,8 +852,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.K34pxV6XsxhoZRiQ": {
-        "data": {
+    "Compendium.wfrp4e-core.items.K34pxV6XsxhoZRiQ": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -882,7 +882,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.FOm0hZjT5dDJgJsy": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ghyran)",
                 "Dodge",
@@ -908,8 +908,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.1tHkTZYaauicIh8I": {
-        "data": {
+    "Compendium.wfrp4e-core.items.1tHkTZYaauicIh8I": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -945,8 +945,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.vI0oorwbZdlszudf": {
-        "data": {
+    "Compendium.wfrp4e-core.items.vI0oorwbZdlszudf": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -991,8 +991,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.talents.BYChSVfMG004eflQ": {
-        "data": {
+    "Compendium.wfrp4e-core.items.BYChSVfMG004eflQ": {
+        "system": {
             "description": {
                 "value": "<p>You instinctively understand the language of Magick, and are capable of articulating the most complex phrases rapidly without error.&nbsp; Whenever you roll on a miscast table as a result of a successful Casting Test, you may apply a -10 modifier to the table result for each level of this talent. If the result is 0 or below, either roll on the lesser miscat table with the same modifier, or the miscast is nuillifed if it was a Minor Miscast.</p>"
             }
@@ -1022,8 +1022,8 @@
         ],
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.q3dEaQLL3ZYCZtU4": {
-        "data": {
+    "Compendium.wfrp4e-core.items.q3dEaQLL3ZYCZtU4": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1039,7 +1039,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.qoFHBdGFMMNdLsS0": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Chamon)",
                 "Intuition",
@@ -1060,7 +1060,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.nBTA2gulRmVTqbAg": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ghyran)",
                 "Dodge",
@@ -1081,7 +1081,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.qxQ7mix9uVxDG0Ev": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Hysh)",
                 "Entertain (Singing)",
@@ -1101,8 +1101,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.kOfcQJQOgmGsqA5U": {
-        "data": {
+    "Compendium.wfrp4e-core.items.kOfcQJQOgmGsqA5U": {
+        "system": {
             "flaws": {
                 "value": [
                     {
@@ -1114,8 +1114,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.RHkj94yUJp620xr1": {
-        "data": {
+    "Compendium.wfrp4e-core.items.RHkj94yUJp620xr1": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1136,7 +1136,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.7htxL8GBQQgu7o4Z": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Chamon)",
                 "Intuition",
@@ -1163,7 +1163,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.D1z8KMZHxOaX9h7s": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Chamon)",
                 "Intuition",
@@ -1190,7 +1190,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.z68pp7fmwamKE9v2": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Azyr)",
                 "Intuition",
@@ -1215,7 +1215,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.PxiWFSSOsRVAjx8i": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ghyran)",
                 "Dodge",
@@ -1240,7 +1240,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.2kHrVyBJURfTeItC": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Hysh)",
                 "Entertain (Singing)",
@@ -1267,7 +1267,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.pwvyjPpzrmIfx7LP": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Hysh)",
                 "Entertain (Singing)",
@@ -1294,7 +1294,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.xp2jXItHqZ1O3fV1": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Aqshy)",
                 "Cool",
@@ -1318,8 +1318,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.careers.1DIMUn1Cj5rohWJV": {
-        "data": {
+    "Compendium.wfrp4e-core.items.1DIMUn1Cj5rohWJV": {
+        "system": {
             "skills": [
                 "Channelling (Any Color)",
                 "Dodge",
@@ -1343,8 +1343,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.talents.0hn6UaKq8CoZP2zD": {
-        "data": {
+    "Compendium.wfrp4e-core.items.0hn6UaKq8CoZP2zD": {
+        "system": {
             "tests": {
                 "value": ""
             }
@@ -1379,8 +1379,8 @@
         ],
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.G2yEH6caM0FJ9s0G": {
-        "data": {
+    "Compendium.wfrp4e-core.items.G2yEH6caM0FJ9s0G": {
+        "system": {
             "damage": {
                 "value": "SB+4"
             },
@@ -1411,8 +1411,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.Bda4Wvnlt3q5zkKC": {
-        "data": {
+    "Compendium.wfrp4e-core.items.Bda4Wvnlt3q5zkKC": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1423,8 +1423,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.PnYGK5FPgEGM1Ck3": {
-        "data": {
+    "Compendium.wfrp4e-core.items.PnYGK5FPgEGM1Ck3": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1461,7 +1461,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.vQuqedgxchpBwvFD": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Aqshy)",
                 "Cool",
@@ -1482,7 +1482,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.fGaS3pBRfv05GzBO": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Aqshy)",
                 "Cool",
@@ -1508,8 +1508,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.GkeMJrsqxQIek1xK": {
-        "data": {
+    "Compendium.wfrp4e-core.items.GkeMJrsqxQIek1xK": {
+        "system": {
             "damage": {
                 "value": "SB+2"
             },
@@ -1532,8 +1532,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.Uuu0bA2DmNp8o2JF": {
-        "data": {
+    "Compendium.wfrp4e-core.items.Uuu0bA2DmNp8o2JF": {
+        "system": {
             "damage": {
                 "value": "SB+3"
             },
@@ -1550,8 +1550,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.M23N8sjzEp16abQQ": {
-        "data": {
+    "Compendium.wfrp4e-core.items.M23N8sjzEp16abQQ": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1591,8 +1591,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.8dKmuti5IuIs9AJA": {
-        "data": {
+    "Compendium.wfrp4e-core.items.8dKmuti5IuIs9AJA": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1628,7 +1628,7 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.NyIwm2Ge60jnUZft": {
+    "Compendium.wfrp4e-core.items.NyIwm2Ge60jnUZft": {
         "flags": {
             "wfrp4e": {
                 "optimalRange": "short"
@@ -1636,7 +1636,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.Jg8DwOfDXBvGiQT0": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ulgu)",
                 "Intuition",
@@ -1659,15 +1659,15 @@
     "Compendium.arcane-marks-careers.arcanecareers.JSh5YtZMiJrS28UN": {
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.CRNrEnLXTGXVT1UW": {
+    "Compendium.wfrp4e-core.items.CRNrEnLXTGXVT1UW": {
         "flags": {
             "wfrp4e": {
                 "optimalRange": "short"
             }
         }
     },
-    "Compendium.wfrp4e-archives1.archives1-items.7cVsB1Ss3cXMySl5": {
-        "data": {
+    "Compendium.wfrp4e-archives1.items.7cVsB1Ss3cXMySl5": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1683,8 +1683,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.7Bpc5I8Arucy3w4q": {
-        "data": {
+    "Compendium.wfrp4e-core.items.7Bpc5I8Arucy3w4q": {
+        "system": {
             "damage": {
                 "value": "SB + 2"
             }
@@ -1695,8 +1695,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.zIuarD5mB0EF0ji0": {
-        "data": {
+    "Compendium.wfrp4e-core.items.zIuarD5mB0EF0ji0": {
+        "system": {
             "damage": {
                 "value": "SB+3"
             },
@@ -1722,8 +1722,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.KSwMbO8dqISoGuIo": {
-        "data": {
+    "Compendium.wfrp4e-core.items.KSwMbO8dqISoGuIo": {
+        "system": {
             "damage": {
                 "value": "SB + 3"
             }
@@ -1734,8 +1734,8 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.Xjwk84KnOKDaiZs1": {
-        "data": {
+    "Compendium.wfrp4e-core.items.Xjwk84KnOKDaiZs1": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1750,7 +1750,7 @@
             }
         }
     },
-    "Compendium.wfrp4e-core.trappings.bwyUJua7I9hNg9WS": {
+    "Compendium.wfrp4e-core.items.bwyUJua7I9hNg9WS": {
         "flags": {
             "wfrp4e": {
                 "optimalRange": "short"
@@ -1758,7 +1758,7 @@
         }
     },
     "Compendium.arcane-marks-careers.arcanecareers.Y2ULm27eRXzBwDwW": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Shyish)",
                 "Dodge",
@@ -1779,7 +1779,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.nLQP9P5mh8Zj5ByE": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Ulgu)",
                 "Intuition",
@@ -1800,7 +1800,7 @@
         "flags": {}
     },
     "Compendium.arcane-marks-careers.arcanecareers.lfqDYa6Glg2OUONa": {
-        "data": {
+        "system": {
             "skills": [
                 "Channelling (Azyr)",
                 "Intuition",
@@ -1820,8 +1820,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.CdP1xLEJbe289beI": {
-        "data": {
+    "Compendium.wfrp4e-core.items.CdP1xLEJbe289beI": {
+        "system": {
             "qualities": {
                 "value": [
                     {
@@ -1849,8 +1849,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.careers.JeWuOwm0nM4V1brh": {
-        "data": {
+    "Compendium.wfrp4e-core.items.JeWuOwm0nM4V1brh": {
+        "system": {
             "skills": [
                 "Channelling (Any Color)",
                 "Dodge",
@@ -1870,8 +1870,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.careers.bTPBxrayfzeVmGsh": {
-        "data": {
+    "Compendium.wfrp4e-core.items.bTPBxrayfzeVmGsh": {
+        "system": {
             "skills": [
                 "Channelling (Any Color)",
                 "Dodge",
@@ -1897,8 +1897,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.careers.WiMLDa950d9wsbbZ": {
-        "data": {
+    "Compendium.wfrp4e-core.items.WiMLDa950d9wsbbZ": {
+        "system": {
             "skills": [
                 "Channelling (Any Color)",
                 "Dodge",
@@ -1912,8 +1912,8 @@
         },
         "flags": {}
     },
-    "Compendium.wfrp4e-core.trappings.N3aHfG4XASsiNoRv": {
-        "data": {
+    "Compendium.wfrp4e-core.items.N3aHfG4XASsiNoRv": {
+        "system": {
             "qualities": {
                 "value": [
                     {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "wfrp4e",
   "title": "Warhammer Fantasy Roleplay 4th Edition",
   "description": "A comprehensive system for running grim and perilous games of Warhammer Fantasy Roleplay in the Foundry VTT environment.",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "authors" : [
     {
       "name": "Moo Man",
@@ -70,6 +70,6 @@
   "templateVersion":3,
   "socket": true,
   "manifest" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/latest/download/system.json",
-  "download" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/download/8.0.0/wfrp4e.zip",
+  "download" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/download/8.0.1/wfrp4e.zip",
   "url" : "https://github.com/moo-man/WFRP4e-FoundryVTT"
 }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "wfrp4e",
   "title": "Warhammer Fantasy Roleplay 4th Edition",
   "description": "A comprehensive system for running grim and perilous games of Warhammer Fantasy Roleplay in the Foundry VTT environment.",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "authors" : [
     {
       "name": "Moo Man",
@@ -70,6 +70,6 @@
   "templateVersion":3,
   "socket": true,
   "manifest" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/latest/download/system.json",
-  "download" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/download/8.0.1/wfrp4e.zip",
+  "download" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/download/8.0.2/wfrp4e.zip",
   "url" : "https://github.com/moo-man/WFRP4e-FoundryVTT"
 }


### PR DESCRIPTION
Ticking every box from Penetrating Values to Item Changes in the homebrew settings didn't seem to do anything to Core items, so I dug through the files a bit and came up with this:
- The id's in items.json didn't seem to match the ones in the compendium so I changed them.
- Accessing (and changing) items through the "data" field was deprecated in v10 so I changed it to "system".
- Same changes apply to Archives vol1 items, but Arcane Marks are left unchanged.
- Bonus spelling fixes to please Tzeentch.