### PR TITLE
Various Market QoL improvements

### DIFF
--- a/modules/system/chat-wfrp4e.js
+++ b/modules/system/chat-wfrp4e.js
@@ -325,27 +325,12 @@ export default class ChatWFRP {
     // data-button tells us what button was clicked
     switch ($(event.currentTarget).attr("data-button")) {
       case "rollAvailability":
-        MarketWFRP4e.generateSettlementChoice($(event.currentTarget).attr("data-rarity"));
+        MarketWFRP4e.generateSettlementChoice($(event.currentTarget).attr("data-rarity"), $(event.currentTarget).attr("data-name"));
         break;
       case "payItem":
         if (!game.user.isGM) {
-          let actor = game.user.character;
-          let itemData
-          if (msg.flags.transfer)
-            itemData = JSON.parse(msg.flags.transfer).data
-          if (actor) {
-            let money = MarketWFRP4e.payCommand($(event.currentTarget).attr("data-pay"), actor);
-            if (money) {
-              WFRP_Audio.PlayContextAudio({ item: { "type": "money" }, action: "lose" })
-              await actor.updateEmbeddedDocuments("Item", money);
-              if (itemData) {
-                await actor.createEmbeddedDocuments("Item", [itemData])
-                ui.notifications.notify(game.i18n.format("MARKET.ItemAdded", { item: itemData.name, actor: actor.name }))
-              }
-            }
-          } else {
-            ui.notifications.notify(game.i18n.localize("MARKET.NotifyNoActor"));
-          }
+          let payString = $(event.currentTarget).attr("data-pay");
+          MarketWFRP4e.handlePlayerPayment({msg, payString})
         } else {
           ui.notifications.notify(game.i18n.localize("MARKET.NotifyUserMustBePlayer"));
         }
@@ -384,6 +369,7 @@ export default class ChatWFRP {
         break;
       case "rollAvailabilityTest":
         let options = {
+          name: $(event.currentTarget).attr("data-name"),
           settlement: $(event.currentTarget).attr("data-settlement").toLowerCase(),
           rarity: $(event.currentTarget).attr("data-rarity").toLowerCase(),
           modifier: 0

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -2,7 +2,6 @@ import MarketWFRP4e from "../apps/market-wfrp4e.js";
 import ItemWfrp4e from "../item/item-wfrp4e.js";
 import PropertiesMixin from "../model/item/components/properties.js";
 import ChatWFRP from "./chat-wfrp4e.js";
-import WFRP_Audio from "./audio-wfrp4e.js";
 
 
 /**

--- a/modules/system/utility-wfrp4e.js
+++ b/modules/system/utility-wfrp4e.js
@@ -2,6 +2,7 @@ import MarketWFRP4e from "../apps/market-wfrp4e.js";
 import ItemWfrp4e from "../item/item-wfrp4e.js";
 import PropertiesMixin from "../model/item/components/properties.js";
 import ChatWFRP from "./chat-wfrp4e.js";
+import WFRP_Audio from "./audio-wfrp4e.js";
 
 
 /**
@@ -692,6 +693,8 @@ export default class WFRP_Utility {
     let payString = $(event.currentTarget).attr("data-pay")
     if (game.user.isGM)
       MarketWFRP4e.generatePayCard(payString);
+    else
+      MarketWFRP4e.handlePlayerPayment({payString});
   }
 
   static handleCreditClick(event) {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1042,6 +1042,8 @@
     "MARKET.d": "d",
     "MARKET.CreditCommandNotAllowed" : "Only GMs are allowed to use this command.",
     "MARKET.PaidBy" : "Paid by:",
+    "MARKET.PaidFor": "<b>Purchased product:</b> {product}",
+    "MARKET.For": "for",
     "MARKET.ReceivedBy" : "Received by:",
     "MARKET.MoneyTransactionWrongCommand" : "Wrong syntax. Please format your command like in the following examples:",
     "MARKET.PayCommandExample" : "/pay 3gc2bp<br>/pay 450bp<br>/pay 2ss12bp4gc<br>/pay 1gc John<br>/pay 12ss Kastor Lieberung",

--- a/static/templates/chat/market/market-pay.hbs
+++ b/static/templates/chat/market/market-pay.hbs
@@ -1,6 +1,6 @@
 <div>
     <h3><b>{{localize "MARKET.PayRequest"}}</b></h3>
-    {{QtGC}} {{localize "MARKET.Abbrev.GC"}}, {{QtSS}} {{localize "MARKET.Abbrev.SS"}}, {{QtBP}} {{localize "MARKET.Abbrev.BP"}}
+    {{QtGC}} {{localize "MARKET.Abbrev.GC"}}, {{QtSS}} {{localize "MARKET.Abbrev.SS"}}, {{QtBP}} {{localize "MARKET.Abbrev.BP"}} {{#if product}}{{localize "MARKET.For"}} {{product}}{{/if}}
 </div>
 <span class="chat-card-button-area">
     <a class='chat-card-button market-button' data-button='payItem' data-pay="{{payRequest}}">{{localize "MARKET.PayForItem"}}</a>

--- a/static/templates/chat/market/market-settlement.hbs
+++ b/static/templates/chat/market/market-settlement.hbs
@@ -2,7 +2,7 @@
     <h3><b>{{localize "MARKET.SelectSettlementSize"}}</b></h3>
 </div>
 <span class="chat-card-button-area">
-    <a class='chat-card-button market-button' data-button='rollAvailabilityTest' data-rarity="{{rarity}}" data-settlement="{{localize 'MARKET.Village'}}">{{localize "MARKET.Village"}}</a>
-    <a class='chat-card-button market-button' data-button='rollAvailabilityTest' data-rarity="{{rarity}}" data-settlement="{{localize 'MARKET.Town'}}">{{localize "MARKET.Town"}}</a>
-    <a class='chat-card-button market-button' data-button='rollAvailabilityTest' data-rarity="{{rarity}}" data-settlement="{{localize 'MARKET.City'}}">{{localize "MARKET.City"}}</a>
+    <a class='chat-card-button market-button' data-button='rollAvailabilityTest' data-name="{{name}}" data-rarity="{{rarity}}" data-settlement="{{localize 'MARKET.Village'}}">{{localize "MARKET.Village"}}</a>
+    <a class='chat-card-button market-button' data-button='rollAvailabilityTest' data-name="{{name}}" data-rarity="{{rarity}}" data-settlement="{{localize 'MARKET.Town'}}">{{localize "MARKET.Town"}}</a>
+    <a class='chat-card-button market-button' data-button='rollAvailabilityTest' data-name="{{name}}" data-rarity="{{rarity}}" data-settlement="{{localize 'MARKET.City'}}">{{localize "MARKET.City"}}</a>
 </span>

--- a/static/templates/chat/post-item.hbs
+++ b/static/templates/chat/post-item.hbs
@@ -18,8 +18,8 @@
     </span>
 
     <span class="chat-card-button-area">
-        <a class='chat-card-button market-button' data-button='rollAvailability' data-rarity="{{system.availability.value}}">{{localize "MARKET.RollForAvailability"}}</a>
-        <a class='chat-card-button market-button' data-button='payItem' data-pay="{{system.price.gc}}{{localize 'MARKET.Abbrev.GC'}}{{system.price.ss}}{{localize 'MARKET.Abbrev.SS'}}{{system.price.bp}}{{localize 'MARKET.Abbrev.BP'}}">{{localize "MARKET.PayForItem"}}</a>
+        <a class='chat-card-button market-button' data-button='rollAvailability' data-rarity="{{system.availability.value}}" data-name="{{name}}">{{localize "MARKET.RollForAvailability"}}</a>
+        <a class='chat-card-button market-button' data-button='payItem' data-pay="{{system.price.gc}}{{localize 'MARKET.Abbrev.GC'}}{{system.price.ss}}{{localize 'MARKET.Abbrev.SS'}}{{system.price.bp}}{{localize 'MARKET.Abbrev.BP'}},{{name}}">{{localize "MARKET.PayForItem"}}</a>
     </span>
     {{/if}}
 


### PR DESCRIPTION
This Pull Request provides 4 QoL changes to the Market workflow, all centered around giving more context to Payment and Availability Tests.

## Allow Players to click on `@Pay` links
I wanted to create my players a "Menu" of an Inn, using either pinned Chat Message or a Journal (irrelevant), which would include multiple options of `@Pay` messages, for example:

```
@Pay[1ss]{Breakfast}
@Pay[5bp]{Pint of quality beer}
```
However, system would not allow players to click on those buttons.

<ins>This Pull Requests allows Players to click that button and pay the amount.</ins>

## Add context to Item's Availability roll and Payment Response

Whenever someone rolls for availability or purchases a posted Item, there is no context clue as to what item that is. While it might not matter with single item, sometimes several Items could be posted to chat (for example several types of draughts, arrows or whatever), and it would be helpful to see who purchases what, but more importantly: **what is available**.

<ins>This Pull Request adds context information to those messages:</ins>
![image](https://github.com/user-attachments/assets/c94c56a4-033c-4c7f-860e-6a37133b522a)

## Allow to add context to the `@Pay` link
Whenever someone pays using `@Pay` link (look 1st change), or by clicking `Pay` button on Chat Message generated when GM clicked on a `@Pay` link, there is no clue as to what that payment is for. 

<ins>This Pull Request allows providing context information to the `@Pay` link, which is carried and displayed on following messages:</ins>
![image](https://github.com/user-attachments/assets/3096819d-ee64-4e9f-8d39-d29b6f39adce)
Above was generated with the following syntax:
```
@Pay[1ss6bp,Room at Inn]{Room at Inn (1 shilling and 6 pennies)}
@Pay[2ss,Warm Bath]{Warm Bath (2 shillings)}
```
Worth noting is that this syntax is optional and if omitted, the Payment Response messages will look just as they always did. 

## Add context to `/pay` command
Similar to `@Pay` link, but this is trickier, because the context cannot have spaces - as those denote Players and Actors.

But this Pull Request allows the `/pay` command to have single word context, for example `/pay 11bp,breakfast Gina`

- Closes #674

![image](https://github.com/user-attachments/assets/3b00047b-336a-491f-8268-2e5df1071257)
