### PR TITLE
Make tables path uniform for all miscasts across both Cast and Channel Tests

### DIFF
--- a/modules/system/rolls/cast-test.js
+++ b/modules/system/rolls/cast-test.js
@@ -328,7 +328,7 @@ export default class CastTest extends TestWFRP {
     }
     if (this.result.nullminormis)
     {
-      this.result.tables.nullminormis = {
+      this.result.tables.miscast = {
         label : this.result.nullminormis,
         class : "fumble-roll",
         key : "minormis",
@@ -345,7 +345,7 @@ export default class CastTest extends TestWFRP {
     }
     if (this.result.nullmajormis)
     {
-      this.result.tables.nullmajormis = {
+      this.result.tables.miscast = {
         label : this.result.nullmajormis,
         class : "fumble-roll",
         key : "majormis",
@@ -362,7 +362,7 @@ export default class CastTest extends TestWFRP {
     }
     if (this.result.nullcatastrophicmis)
     {
-      this.result.tables.nullcatastrophicmis = {
+      this.result.tables.miscast = {
         label : this.result.nullcatastrophicmis,
         class : "fumble-roll",
         key : "nullcatastrophicmis",

--- a/modules/system/rolls/cast-test.js
+++ b/modules/system/rolls/cast-test.js
@@ -328,7 +328,7 @@ export default class CastTest extends TestWFRP {
     }
     if (this.result.nullminormis)
     {
-      this.result.tables.miscast = {
+      this.result.tables.nullminormis = {
         label : this.result.nullminormis,
         class : "fumble-roll",
         key : "minormis",
@@ -345,7 +345,7 @@ export default class CastTest extends TestWFRP {
     }
     if (this.result.nullmajormis)
     {
-      this.result.tables.miscast = {
+      this.result.tables.nullmajormis = {
         label : this.result.nullmajormis,
         class : "fumble-roll",
         key : "majormis",
@@ -362,7 +362,7 @@ export default class CastTest extends TestWFRP {
     }
     if (this.result.nullcatastrophicmis)
     {
-      this.result.tables.miscast = {
+      this.result.tables.nullcatastrophicmis = {
         label : this.result.nullcatastrophicmis,
         class : "fumble-roll",
         key : "nullcatastrophicmis",

--- a/modules/system/rolls/channel-test.js
+++ b/modules/system/rolls/channel-test.js
@@ -129,7 +129,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.minormis)
     {
-      this.result.tables.minormis = {
+      this.result.tables.miscast = {
         label : this.result.minormis,
         class : "fumble-roll",
         key : "minormis"
@@ -137,7 +137,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.nullminormis)
     {
-      this.result.tables.minormis = {
+      this.result.tables.miscast = {
         label : this.result.nullminormis,
         class : "fumble-roll",
         key : "minormis",
@@ -146,7 +146,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.majormis)
     {
-      this.result.tables.majormis = {
+      this.result.tables.miscast = {
         label : this.result.majormis,
         class : "fumble-roll",
         key : "majormis",
@@ -154,7 +154,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.nullmajormis)
     {
-      this.result.tables.majormis = {
+      this.result.tables.miscast = {
         label : this.result.nullmajormis,
         class : "fumble-roll",
         key : "majormis",
@@ -163,7 +163,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.catastrophicmis)
     {
-      this.result.tables.catastrophicmis = {
+      this.result.tables.miscast = {
         label : this.result.catastrophicmis,
         class : "fumble-roll",
         key : "catastrophicmis",
@@ -171,7 +171,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.nullcatastrophicmis)
     {
-      this.result.tables.catastrophicmis = {
+      this.result.tables.miscast = {
         label : this.result.nullcatastrophicmis,
         class : "fumble-roll",
         key : "nullcatastrophicmis",

--- a/modules/system/rolls/channel-test.js
+++ b/modules/system/rolls/channel-test.js
@@ -137,7 +137,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.nullminormis)
     {
-      this.result.tables.miscast = {
+      this.result.tables.nullminormis = {
         label : this.result.nullminormis,
         class : "fumble-roll",
         key : "minormis",
@@ -154,7 +154,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.nullmajormis)
     {
-      this.result.tables.miscast = {
+      this.result.tables.nullmajormis = {
         label : this.result.nullmajormis,
         class : "fumble-roll",
         key : "majormis",
@@ -171,7 +171,7 @@ export default class ChannelTest extends TestWFRP {
     }
     if (this.result.nullcatastrophicmis)
     {
-      this.result.tables.miscast = {
+      this.result.tables.nullcatastrophicmis = {
         label : this.result.nullcatastrophicmis,
         class : "fumble-roll",
         key : "nullcatastrophicmis",


### PR DESCRIPTION
As far as I know, miscasts do not stack, but only worst appears.

Wasn't sure about grimoire, left it with unique key. 