### PR TITLE
feat: Add option to remove resetting targets on each roll

### DIFF
--- a/modules/apps/roll-dialog/roll-dialog.js
+++ b/modules/apps/roll-dialog/roll-dialog.js
@@ -62,7 +62,7 @@ export default class RollDialog extends WarhammerRollDialog {
             this.resolve(test);
         }
         this.close();
-        if (canvas.scene && !this.options.skipTargets)
+        if (canvas.scene && !this.options.skipTargets && game.settings.get("wfrp4e", "targetReset"))
         {
             game.user.updateTokenTargets([]);
             game.user.broadcastActivity({targets: []});

--- a/modules/hooks/init.js
+++ b/modules/hooks/init.js
@@ -721,6 +721,15 @@ export default function() {
       type: Object
     });
 
+    game.settings.register("wfrp4e", "targetReset", {
+      name: "SETTINGS.TargetReset",
+      hint: "SETTINGS.TargetResetHint",
+      scope: "client",
+      config: true,
+      default: true,
+      type: Boolean
+    });
+
     // Pre-load templates
     loadTemplates([
       "systems/wfrp4e/templates/actors/character/character-main.hbs",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -190,6 +190,8 @@
     "SETTINGS.useWoMInfluencesHint" : "Use Malignant Influences rules provided in the Winds of Magic Supplement, described on page 22",
     "SETTINGS.ChannellingIngredients" : "Channelling Ingredients",
     "SETTINGS.ChannellingIngredientsHint" : "Have Ingredients apply their benefits to Channelling Tests as well as Casting Tests",
+    "SETTINGS.TargetReset": "Reset Targets",
+    "SETTINGS.TargetResetHint": "Will clear Targets for User after each Roll",
 
     "MOO.Prone": "<br><br><b>Moo's House Rule</b>: You are considered one range band farther away when determining ranged attacks.",
     "MOO.Broken": "You are terrified, defeated, panicked, or otherwise convinced you are going to die. On your turn, your Move and Action must be used to run away as fast as possible until you are in a good hiding place beyond the sight of any enemy; then you can use your Action on a Skill that allows you to hide more effectively. You also receive a penalty of –10 to all Tests not involving running and hiding.<br><br>You cannot Test to rally from being Broken if you are Engaged with an enemy. If you are unengaged, at the end of each Round, you may attempt a Cool Test to remove a Broken Condition, with each SL removing an extra Broken Condition, and the Difficulty determined by the circumstances you currently find yourself: it is much easier to rally when hiding behind a barrel down an alleyway far from danger (Average +20) than it is when three steps from a slavering Daemon screaming for your blood (Very Hard –30).<br><br>If you spend a full Round in hiding out of line-of-sight of any enemy, you remove 1 Broken Condition.<br><br><strike>Once all Broken Conditions are removed, gain 1 Fatigued Condition</strike>.",


### PR DESCRIPTION
Adds a client side setting to not reset targets after each roll.
Idea is that sometimes things don't die in 1 roll and need to retargeted.
This allows GM to have it reset but allows players to turn it off as they keep hitting the same thing.

Can rewrite this to be global and/or a select kind of setting ex: Reset for All, Reset for GM, Don't reset weapon rolls, etc...

![image](https://github.com/user-attachments/assets/bf1258ff-a81e-450f-978c-9b2a0860ebde)