### PR TITLE
Add option to suppress XP award messages in chat

### DIFF
--- a/modules/model/actor/character.js
+++ b/modules/model/actor/character.js
@@ -176,13 +176,14 @@ export class CharacterModel extends StandardActorModel {
         return this.parent.itemTags["career"].find(c => c.current.value)
     }
     
-    awardExp(amount, reason, message=null) 
+    awardExp(amount, reason, message=null, suppressChat=false) 
     {
       let experience = foundry.utils.duplicate(this.details.experience)
       experience.total += amount
       experience.log.push({ reason, amount, spent: experience.spent, total: experience.total, type: "total" })
       this.parent.update({ "system.details.experience": experience }, {fromMessage : message});
-      ChatMessage.create({ content: game.i18n.format("CHAT.ExpReceived", { amount, reason }), speaker: { alias: this.name } })
+      if (!suppressChat) 
+        ChatMessage.create({ content: game.i18n.format("CHAT.ExpReceived", { amount, reason }), speaker: { alias: this.name } })
     }
 
     addToExpLog(amount, reason, newSpent, newTotal) 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "wfrp4e",
   "title": "Warhammer Fantasy Roleplay 4th Edition",
   "description": "A comprehensive system for running grim and perilous games of Warhammer Fantasy Roleplay in the Foundry VTT environment.",
-  "version": "8.4.1",
+  "version": "8.5.0",
   "authors" : [
     {
       "name": "Moo Man",
@@ -63,15 +63,15 @@
     "requires": [{
       "id": "warhammer-lib",
       "type": "module",
-      "manifest": "https://raw.githubusercontent.com/moo-man/WarhammerLibrary-FVTT/1.5.0/module.json",
+      "manifest": "https://raw.githubusercontent.com/moo-man/WarhammerLibrary-FVTT/1.7.0/module.json",
       "compatibility": {
-        "minimum" : "1.5.0",
-        "verified": "1.5.0"
+        "minimum" : "1.7.0",
+        "verified": "1.7.0"
       }
     }]
   },
   "socket": true,
   "manifest" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/latest/download/system.json",
-  "download" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/download/8.4.1/wfrp4e.zip",
+  "download" :  "https://github.com/moo-man/WFRP4e-FoundryVTT/releases/download/8.5.0/wfrp4e.zip",
   "url" : "https://github.com/moo-man/WFRP4e-FoundryVTT"
 }


### PR DESCRIPTION
I'd like to leverage native `awardExp` functionality for the extended XP features in GM Toolkit. 
However, this creates additional non-specific chat messages per awardee, which is unwanted when bulk processing XP across party members and henchmen. 
This change adds an option to suppress these messages, which will help reduce chat log noise and provide a cleaner ux for players and GMs.  
The default option preserves existing behaviour without additional changes. 

![image](https://github.com/user-attachments/assets/642c5dd4-1a1a-4163-98eb-4a5651aeb320)

