### PR TITLE
Morning fixes

### DIFF
--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -470,24 +470,6 @@ export default function() {
 
     // Pre-load templates
     foundry.applications.handlebars.loadTemplates([
-      "systems/wfrp4e/templates/actors/character/character-main.hbs",
-      "systems/wfrp4e/templates/actors/actor-combat.hbs",
-      "systems/wfrp4e/templates/actors/actor-effects.hbs",
-      "systems/wfrp4e/templates/actors/actor-biography.hbs",
-      "systems/wfrp4e/templates/actors/actor-inventory.hbs",
-      "systems/wfrp4e/templates/actors/actor-skills.hbs",
-      "systems/wfrp4e/templates/actors/actor-magic.hbs",
-      "systems/wfrp4e/templates/actors/actor-religion.hbs",
-      "systems/wfrp4e/templates/actors/actor-talents.hbs",
-      "systems/wfrp4e/templates/actors/actor-notes.hbs",
-      "systems/wfrp4e/templates/actors/npc/npc-careers.hbs",
-      "systems/wfrp4e/templates/actors/creature/creature-main.hbs",
-      "systems/wfrp4e/templates/actors/creature/creature-notes.hbs",
-      "systems/wfrp4e/templates/actors/creature/creature-main.hbs",
-      "systems/wfrp4e/templates/actors/vehicle/vehicle-main.hbs",
-      "systems/wfrp4e/templates/actors/vehicle/vehicle-cargo.hbs",
-      "systems/wfrp4e/templates/actors/vehicle/vehicle-description.hbs",
-      "systems/wfrp4e/templates/actors/vehicle/vehicle-effects.hbs",
       "systems/wfrp4e/templates/sheets/partials/container-contents.hbs",
       "systems/wfrp4e/templates/partials/armour-location.hbs",
       "systems/wfrp4e/templates/partials/item-container.hbs",
@@ -498,9 +480,6 @@ export default function() {
       "systems/wfrp4e/templates/partials/list-effect.hbs",
       "systems/wfrp4e/templates/chat/roll/test-card.hbs",
       "systems/wfrp4e/templates/chat/help/chat-command-display-info.hbs",
-      "systems/wfrp4e/templates/items/item-header.hbs",
-      "systems/wfrp4e/templates/items/item-description.hbs",
-      "systems/wfrp4e/templates/items/item-effects.hbs",
     ]);
 
     foundry.applications.handlebars.loadTemplates({
@@ -514,7 +493,6 @@ export default function() {
       vehicleArmour: "systems/wfrp4e/templates/sheets/partials/vehicle-armour.hbs",
       itemProperties: "systems/wfrp4e/templates/sheets/partials/item-properties.hbs",
       extraOvercast: "systems/wfrp4e/templates/sheets/partials/extra-overcast.hbs",
-      aspectDetails: 'systems/wfrp4e/templates/items/partials/item-aspect-details.hbs',
       "chargen.species.preview": 'systems/wfrp4e/templates/apps/chargen/partials/species-preview.hbs'
     });
 

--- a/src/model/item/generic.js
+++ b/src/model/item/generic.js
@@ -37,11 +37,6 @@ export class GenericAspectModel extends BaseItemModel
         return this.constructor.plural;
     }
 
-    get detailsPartial()
-    {
-        return 'aspectDetails';
-    }
-
     /**
      * Whether the Aspect can be "used" or not. Usage may – depending on Aspect – mean Rolling, initiating a Test,
      * or doing something else entirely.

--- a/src/system/tables-wfrp4e.js
+++ b/src/system/tables-wfrp4e.js
@@ -408,8 +408,8 @@ export default class WFRP_Tables {
         let item = collection.get(result.object.documentId)
         if (item && item.documentName == "Item")
         {
-          item.postItem(undefined, {"flags.wfrp4e.sourceMessageId" : options.messageId});
-          return {}
+          await item.postItem(undefined, {"flags.wfrp4e.sourceMessageId" : options.messageId});
+          return null;
         }
       }
 

--- a/src/system/tables-wfrp4e.js
+++ b/src/system/tables-wfrp4e.js
@@ -26,10 +26,11 @@ export default class WFRP_Tables {
     }
     else {
       // Call tables class to roll and return html
-      game.wfrp4e.tables.formatChatRoll(key, { modifier: modifier, showRoll: true }, column).then(text => {
-        if (!text)
+      game.wfrp4e.tables.formatChatRoll(key, { modifier: modifier, showRoll: true, returnResult: true }, column).then(result => {
+        if (!result)
           return
-        msg.content = text
+        msg.content = result.object?.name.length ? `<strong>${result.object.name}</strong>` : '';
+        msg.content += `<p>${result.result}</p>`;
         ChatMessage.create(msg);
       })
     }
@@ -392,7 +393,7 @@ export default class WFRP_Tables {
     { }
 
     // If the roll is an item, don't post the link to chat, post the item to chat
-    if (result.object?.documentCollection && result.object?.documentId)
+    if (result.object?.documentUuid)
     {
       let collection = game.packs.get(result.object.documentCollection)
 


### PR DESCRIPTION
Fixes:
- Errors when trying to preload missing partials: https://discord.com/channels/787396882875416606/787397718339223603/1369335284222787754
- Non-Item RollTable results not showing up: https://discord.com/channels/170995199584108546/697845419593695362/1369628595273863208
- Item RollTable results showing an additional Chat Message with `[object Object]`

Changes:
- If Text Rolltable Result has a `name` (title, sort of), the resulting Chat Message also displays that.