### PR TITLE
Colors for ruler segment

### DIFF
--- a/src/canvas/token-ruler.js
+++ b/src/canvas/token-ruler.js
@@ -75,23 +75,27 @@ export default class TokenRulerWFRP extends foundry.canvas.placeables.tokens.Tok
     return foundry.utils.mergeObject(style, color);
   }
 
+  /** @override */
   _getSegmentStyle(waypoint) {
     const scale = canvas.dimensions.uiScale;
-    const movement = this.token.actor.system.movementDistance[waypoint.action] || 0;
-    const maxMovement = typeof movement === "object" ? movement[1] : movement;
-    const cost = waypoint.measurement.cost;
+    if  (canvas.scene.grid.type != 0) {
+	   return {width: 4 * scale, color: game.user.color, alpha: 1};
+    } else {
+      const movement = this.token.actor.system.movementDistance[waypoint.action] || 0;
+      const maxMovement = typeof movement === "object" ? movement[1] : movement;
+      const cost = waypoint.measurement.cost;
 
-    // 2-step gradient, different color for immobile, blink and displace
-    let color = this.constructor.STYLES.move.color;
-    if (movement[0] < cost && cost <= maxMovement )
-      color = this.constructor.STYLES.stride.color;
-  	else if (maxMovement < cost)
-  	  color = this.constructor.STYLES.exceed.color;
-  	if  (maxMovement <= 0)
-  	  color = this.constructor.STYLES.immobile.color;
-  	if (["blink", "displace"].includes(waypoint.action))
-  	  color = 0x0000aa;
-
-    return {width: 4 * scale, color: color, alpha: 1};
-  }
+      // 2-step gradient, different color for immobile, blink and displace
+      let color = this.constructor.STYLES.move.color;
+      if (movement[0] < cost && cost <= maxMovement )
+        color = this.constructor.STYLES.stride.color;
+      else if (maxMovement < cost)
+        color = this.constructor.STYLES.exceed.color;
+      if  (maxMovement <= 0)
+        color = this.constructor.STYLES.immobile.color;
+      if (["blink", "displace"].includes(waypoint.action))
+        color = 0x0000aa;
+	  return {width: 4 * scale, color: color, alpha: 1};
+      }
+    }
 }

--- a/src/canvas/token-ruler.js
+++ b/src/canvas/token-ruler.js
@@ -74,4 +74,24 @@ export default class TokenRulerWFRP extends foundry.canvas.placeables.tokens.Tok
 
     return foundry.utils.mergeObject(style, color);
   }
+
+  _getSegmentStyle(waypoint) {
+    const scale = canvas.dimensions.uiScale;
+    const movement = this.token.actor.system.movementDistance[waypoint.action] || 0;
+    const maxMovement = typeof movement === "object" ? movement[1] : movement;
+    const cost = waypoint.measurement.cost;
+
+    // 2-step gradient, different color for immobile, blink and displace
+    let color = this.constructor.STYLES.move.color;
+    if (movement[0] < cost && cost <= maxMovement )
+      color = this.constructor.STYLES.stride.color;
+  	else if (maxMovement < cost)
+  	  color = this.constructor.STYLES.exceed.color;
+  	if  (maxMovement <= 0)
+  	  color = this.constructor.STYLES.immobile.color;
+  	if (["blink", "displace"].includes(waypoint.action))
+  	  color = 0x0000aa;
+
+    return {width: 4 * scale, color: color, alpha: 1};
+  }
 }


### PR DESCRIPTION
This PR adds colors for the ruler segment. The same as the grid highlight. Specially useful for gridless maps.
![Ruler](https://github.com/user-attachments/assets/682064c3-a5cc-4952-a851-0840f6aa814d)
Also used the same colors for immobile. Added a blue color for blink and displace.

I noticed that in gridless maps, many times when moving exactly to the speed limits (walk and run) it shows the next color. I think that is because there are some unseen decimals.

Ideally, the cursor should snap to that limit when it's close, like drag ruler did. But I have no idea on how to do that.