### PR TITLE
[Docs] Add documentation for fan-made modules

### DIFF
--- a/docs/pages/effects/effects.md
+++ b/docs/pages/effects/effects.md
@@ -2,6 +2,7 @@
 layout: default
 title: Active Effects
 has_children: true
+nav_order: 4
 ---
 
 {: .highlight}

--- a/docs/pages/fan-modules.md
+++ b/docs/pages/fan-modules.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: Fan-made Modules
+has_children: true
+nav_order: 30
+---
+
+{: .important}
+> Third-Party Modules are made by the community members as a hobby. They are in no way, shape or form linked to 
+> Moo Man, Cubicle 7, or Games Workshop.
+> 
+> You are generally installing them at your own risk and responsibility, and you should keep in mind that in case any
+> issues arise with the System, your **very first** troubleshooting step should be to **disable all Third-Party Modules**.
+
+Modules on this list may not be up to date. Always check their verified status over the [Foundry VTT website](https://foundryvtt.com/).
+{: .warning}
+
+
+
+# Recommended Modules
+
+I am new to Foundry VTT and/or the WFRP4e game system. What are the best/recommended modules I should install?
+{: .question}
+
+**Answer:** None.
+
+---
+
+Modules can greatly enhance your Foundry VTT experience—but there’s no universal “best” list. Here’s why:
+* **Foundry, WFRP4e, and modules change often.** — Static lists quickly become outdated. Some modules stop being maintained or get replaced by built-in features. Using old lists can cause major issues.
+* **Needs and preferences vary.** — Some GMs want automation, others prefer manual control. A popular module might not suit your style – or you might forget to use it, turning it into unnecessary bloat.
+* **Modules can conflict.** — Especially ones that overhaul similar systems, like dice rolling or chat cards. Be cautious when combining such modules.
+* **Don’t install everything at once.** — It’s tempting, but overwhelming. You’ll struggle to tell which module does what. Add one at a time, read the docs, and test it.
+* **Know core Foundry and WFRP4e first.** — Start with few or no modules. You might like the built-in tools better, and you’ll better understand what modules are changing.
+
+Instead of following big lists, identify specific needs or pain points in your game—then look for modules that solve those. Add them slowly and intentionally.
+
+# WFRP4e specific Modules
+
+Below is the list of community-made modules specifically designed for WFRP4e. 

--- a/docs/pages/macros.md
+++ b/docs/pages/macros.md
@@ -2,6 +2,7 @@
 layout: default
 title: Macros
 has_children: true
+nav_order: 10
 ---
 ## System Generated Macros
 The system generates certain macros with drag and drop functionality.

--- a/docs/pages/modules/chat-commander.md
+++ b/docs/pages/modules/chat-commander.md
@@ -4,6 +4,10 @@ title: Chat Commander – WFRP4e
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/Foundry-Workshop/chat-commander-wfrp4e?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FFoundry-Workshop%2Fchat-commander-wfrp4e%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FFoundry-Workshop%2Fchat-commander-wfrp4e%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
 **Author:** [Forien](https://foundryvtt.com/community/forien) ([discord](https://discord.gg/XkTFv8DRDc))  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/chat-commander-wfrp4e) | [GitHub](https://github.com/Foundry-Workshop/chat-commander-wfrp4e)
 

--- a/docs/pages/modules/chat-commander.md
+++ b/docs/pages/modules/chat-commander.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Chat Commander – WFRP4e
+parent: Fan-made Modules
+---
+
+**Author:** [Forien](https://foundryvtt.com/community/forien) ([discord](https://discord.gg/XkTFv8DRDc))  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/chat-commander-wfrp4e) | [GitHub](https://github.com/Foundry-Workshop/chat-commander-wfrp4e)
+
+This module provides real-time help and autocompletion data for WFRP4e System's chat commands to Chat Commander module.
+
+This module supports the following commands:
+- `/table`, `/cond`, `/prop`, `/char`, `/name`, `/avail`, `/pay`, `/credit`, `/corruption`, `/fear`, `/terror`, `/travel`,
+  `/exp` and `/trade`
+
+## Screenshots
+
+<div style="display: flex; gap: 5px; align-items: flex-end;">
+<img src="https://i.gyazo.com/3784643a149c62b9dd93e3aa7e3ae08e.gif" style="object-fit: none">
+<img src="https://i.gyazo.com/5e40fbd0837189dafe5de7999b317e91.gif" style="object-fit: none">
+</div>

--- a/docs/pages/modules/fan-maps.md
+++ b/docs/pages/modules/fan-maps.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Fan-made Maps
+parent: Fan-made Modules
+---
+
+**Author:** [LeRatier Bretonnien](https://foundryvtt.com/community/leratier-bretonnien)  
+
+## Fan-made maps for Death on the Reik
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-dotr-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-dotr-maps)
+
+This is collection of fan-made maps for Death on the Reik (aka chapter 2 of the Imperial Campaign) for Warhammer 4 system (wfrp4e).
+
+
+## Fan-made Maps for Enemy in Shadows  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-eis-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-eis-maps)
+
+This is collection of fan-made maps for Enemy in Shadows (aka chapter 1 of the Imperial Campaign) for Warhammer 4 system (wfrp4e).
+
+
+## Fan-made maps for Power Behind The Throne  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-pbth-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-pbth-maps/)
+
+This is collection of fan-made maps for Power Behind the Throne (aka chapter 3 of the Imperial Campaign) for Warhammer 4 system (wfrp4e).
+
+
+## Fan-made Ubersreik Maps  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-ubersreik-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-ubersreik)
+
+This is collection of fan-made maps for Ubersreik and its associated scenarios (Starter Kit, Adventures 1, and 2), for Warhammer 4 system (wfrp4e).
+

--- a/docs/pages/modules/fan-maps.md
+++ b/docs/pages/modules/fan-maps.md
@@ -7,24 +7,37 @@ parent: Fan-made Modules
 **Author:** [LeRatier Bretonnien](https://foundryvtt.com/community/leratier-bretonnien)  
 
 ## Fan-made maps for Death on the Reik
+
+![Module Version](https://img.shields.io/gitea/v/release/public/wfrp4e-dotr-maps?gitea_url=https%3A%2F%2Fwww.uberwald.me%2Fgitea&style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-dotr-maps%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-dotr-maps%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-dotr-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-dotr-maps)
 
 This is collection of fan-made maps for Death on the Reik (aka chapter 2 of the Imperial Campaign) for Warhammer 4 system (wfrp4e).
 
 
-## Fan-made Maps for Enemy in Shadows  
+## Fan-made Maps for Enemy in Shadows
+![Module Version](https://img.shields.io/gitea/v/release/public/wfrp4e-eis-maps?gitea_url=https%3A%2F%2Fwww.uberwald.me%2Fgitea&style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-eis-maps%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-eis-maps%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-eis-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-eis-maps)
 
 This is collection of fan-made maps for Enemy in Shadows (aka chapter 1 of the Imperial Campaign) for Warhammer 4 system (wfrp4e).
 
 
-## Fan-made maps for Power Behind The Throne  
+## Fan-made maps for Power Behind The Throne
+![Module Version](https://img.shields.io/gitea/v/release/public/wfrp4e-pbth-maps?gitea_url=https%3A%2F%2Fwww.uberwald.me%2Fgitea&style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-pbth-maps%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-pbth-maps%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-pbth-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-pbth-maps/)
 
 This is collection of fan-made maps for Power Behind the Throne (aka chapter 3 of the Imperial Campaign) for Warhammer 4 system (wfrp4e).
 
 
-## Fan-made Ubersreik Maps  
+## Fan-made Ubersreik Maps
+![Module Version](https://img.shields.io/gitea/v/release/public/wfrp4e-ubersreik?gitea_url=https%3A%2F%2Fwww.uberwald.me%2Fgitea&style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-ubersreik%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-ubersreik%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-ubersreik-maps) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-ubersreik)
 
 This is collection of fan-made maps for Ubersreik and its associated scenarios (Starter Kit, Adventures 1, and 2), for Warhammer 4 system (wfrp4e).

--- a/docs/pages/modules/forien-armoury.md
+++ b/docs/pages/modules/forien-armoury.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Forien's Armoury
+parent: Fan-made Modules
+---
+
+**Author:** [Forien](https://foundryvtt.com/community/forien) ([discord](https://discord.gg/XkTFv8DRDc))  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/forien-armoury) | [GitHub](https://github.com/Forien/foundryvtt-forien-armoury)
+
+This module is a collection of custom trappings and features for WFRP4e. Forien's Armoury started as a compendium of my own custom items and houserules and as the time went by, it got expanded.
+
+- It boasts a vast collection of automated features, from new Item types (Grimoires and Magic Scrolls), through
+  Automated Disease/Injury Progression, to Combat and Casting Fatigue.
+- It contains 24 Macros for both Players and GMs, including checking Career Progress, Repairing Items,
+  Awarding XP (with Companions), creating Spell Ingredients etc.
+- It contains over 150 Items, including 22 Spells, 16 Careers, 13 Talents, 24 Templates, and a lot of Trappings, Traits etc.
+- Journals are provided, describing every feature, homebrew rule, and content in the Module.

--- a/docs/pages/modules/forien-armoury.md
+++ b/docs/pages/modules/forien-armoury.md
@@ -4,6 +4,10 @@ title: Forien's Armoury
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/Forien/foundryvtt-forien-armoury?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FForien%2Ffoundryvtt-forien-armoury%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FForien%2Ffoundryvtt-forien-armoury%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
 **Author:** [Forien](https://foundryvtt.com/community/forien) ([discord](https://discord.gg/XkTFv8DRDc))  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/forien-armoury) | [GitHub](https://github.com/Forien/foundryvtt-forien-armoury)
 

--- a/docs/pages/modules/gm-toolkit.md
+++ b/docs/pages/modules/gm-toolkit.md
@@ -4,6 +4,10 @@ title: GM Toolkit
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/Jagusti/fvtt-wfrp4e-gmtoolkit?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FJagusti%2Ffvtt-wfrp4e-gmtoolkit%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FJagusti%2Ffvtt-wfrp4e-gmtoolkit%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
 **Author:** [Jagusti](https://foundryvtt.com/community/jagusti)  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-gm-toolkit) | [GitHub](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit)
 

--- a/docs/pages/modules/gm-toolkit.md
+++ b/docs/pages/modules/gm-toolkit.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: GM Toolkit
+parent: Fan-made Modules
+---
+
+**Author:** [Jagusti](https://foundryvtt.com/community/jagusti)  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-gm-toolkit) | [GitHub](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit)
+
+Utility module with tweaks, enhancements, and macros to help GMs with game management when running Warhammer Fantasy Roleplay (4e) sessions.  
+Includes features such as:
+- Automating individual and group Advantage
+- Sending Dark Whispers
+- Rolling secret group skill tests
+- Dealing out non-combat damage to multiple actors and vehicles
+- Managing session turnover admin (including adding Experience Points and resetting Fortune)
+- and many more

--- a/docs/pages/modules/more-subspecies.md
+++ b/docs/pages/modules/more-subspecies.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: More Subspecies
+parent: Fan-made Modules
+---
+
+**Author:** [iKindred](https://foundryvtt.com/community/ikindred)  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-more-subspecies) | [GitHub](https://github.com/mcavallo/foundry-vtt-wfrp4e-more-subspecies)
+
+This module adds a collection of new homebrew subspecies to choose from in the WFRP4E character generation.

--- a/docs/pages/modules/more-subspecies.md
+++ b/docs/pages/modules/more-subspecies.md
@@ -4,6 +4,11 @@ title: More Subspecies
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/mcavallo/foundry-vtt-wfrp4e-more-subspecies?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2Fmcavallo%2Ffoundry-vtt-wfrp4e-more-subspecies%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2Fmcavallo%2Ffoundry-vtt-wfrp4e-more-subspecies%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
+
 **Author:** [iKindred](https://foundryvtt.com/community/ikindred)  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-more-subspecies) | [GitHub](https://github.com/mcavallo/foundry-vtt-wfrp4e-more-subspecies)
 

--- a/docs/pages/modules/more-subspecies.md
+++ b/docs/pages/modules/more-subspecies.md
@@ -8,3 +8,22 @@ parent: Fan-made Modules
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-more-subspecies) | [GitHub](https://github.com/mcavallo/foundry-vtt-wfrp4e-more-subspecies)
 
 This module adds a collection of new homebrew subspecies to choose from in the WFRP4E character generation.
+
+![Species selection box](https://raw.githubusercontent.com/mcavallo/foundry-vtt-wfrp4e-more-subspecies/master/.github/docs/cover.jpg)
+
+# Supported species
+
+At the moment, the module supports the following human subspecies:
+
+| Dataset | Subspecies |
+| --- | --- |
+| **Bretonnian Humans** | Bretonnian (Generic), Aquitainian, Artoin, Bastonnian, Bordelen, Brionnian, Carcassonnian, Couronnian, Gisoren, L'Anguillian, Lyonen, Montfortian, Mousillonian, Parravonese, Queneller |
+| **Estalian Humans** | Estalian (Generic) |
+| **Imperial Humans** | Altdorfer, Averlander, Drakenwalder, Hochlander, Middenheimer, Middenlander, Nordlander, Nulner, Ostlander, Ostmarker, Reiklander, Salzenmunder, Sollander, Stirlander, Strigany, Sylvanian, Talabeclander, Talabheimer, Wastelander, Wissenlander |
+| **Kislevite Humans** | Kislevite (Generic), Gospodar, Ropsmenn, Ungol |
+| **Tilean Humans** | Tilean (Generic) |
+
+All subspecies added by this module are prefixed with `*`.
+
+![Species selection box](https://raw.githubusercontent.com/mcavallo/foundry-vtt-wfrp4e-more-subspecies/master/.github/docs/prefixed-subspecies.jpg)
+

--- a/docs/pages/modules/mutant-handbook.md
+++ b/docs/pages/modules/mutant-handbook.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: The Mutant's Handbook
+parent: Fan-made Modules
+---
+
+**Author:** [artantares](https://foundryvtt.com/community/artantares)  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-mutations) | [GitHub](https://github.com/artptz/wfrp4e-mutations)
+
+A WFRP 4e module based on the homebrew content of Anders Hellspong, which was inspired by the WFRP 2e Tome of Corruption

--- a/docs/pages/modules/mutant-handbook.md
+++ b/docs/pages/modules/mutant-handbook.md
@@ -4,6 +4,11 @@ title: The Mutant's Handbook
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/artptz/wfrp4e-mutations?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2Fartptz%2Fwfrp4e-mutations%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2Fartptz%2Fwfrp4e-mutations%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
+
 **Author:** [artantares](https://foundryvtt.com/community/artantares)  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-mutations) | [GitHub](https://github.com/artptz/wfrp4e-mutations)
 

--- a/docs/pages/modules/night-vision.md
+++ b/docs/pages/modules/night-vision.md
@@ -4,6 +4,10 @@ title: Night Vision
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/TheFirst05/fvtt-wfrp4e-night-vision?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FTheFirst05%2Ffvtt-wfrp4e-night-vision%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FTheFirst05%2Ffvtt-wfrp4e-night-vision%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
 **Author:** [StuckintheSea](https://foundryvtt.com/community/stuckinthesea)  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-night-vision) | [GitHub](https://github.com/TheFirst05/fvtt-wfrp4e-night-vision)
 

--- a/docs/pages/modules/night-vision.md
+++ b/docs/pages/modules/night-vision.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Night Vision
+parent: Fan-made Modules
+---
+
+**Author:** [StuckintheSea](https://foundryvtt.com/community/stuckinthesea)  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-night-vision) | [GitHub](https://github.com/TheFirst05/fvtt-wfrp4e-night-vision)
+
+This module helps simulate the Night Vision talent for the Warhammer Fantasy Roleplay 4e system.

--- a/docs/pages/modules/npc-generator.md
+++ b/docs/pages/modules/npc-generator.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: NPC generator
+parent: Fan-made Modules
+---
+
+**Author:** [Matthieu Cailleaux](https://foundryvtt.com/community/mcailleaux)  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4-wfrp4e-npc-generator) | [GitLab](https://gitlab.com/greenskin-foundryvtt/wfrp4e-npc-generator)
+
+This module add functions to :
+- Generate NPC with careers, skills, and talents
+- Generate Creature from the existing template and change traits, skills, talents, size etc ...

--- a/docs/pages/modules/npc-generator.md
+++ b/docs/pages/modules/npc-generator.md
@@ -3,6 +3,9 @@ layout: default
 title: NPC generator
 parent: Fan-made Modules
 ---
+![Module Version](https://img.shields.io/gitlab/v/release/greenskin-foundryvtt/wfrp4e-npc-generator?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgitlab.com%2Fgreenskin-foundryvtt%2Fwfrp4e-npc-generator%2F-%2Fraw%2Fmaster%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgitlab.com%2Fgreenskin-foundryvtt%2Fwfrp4e-npc-generator%2F-%2Fraw%2Fmaster%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
 
 **Author:** [Matthieu Cailleaux](https://foundryvtt.com/community/mcailleaux)  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4-wfrp4e-npc-generator) | [GitLab](https://gitlab.com/greenskin-foundryvtt/wfrp4e-npc-generator)

--- a/docs/pages/modules/tah-wfrp4e.md
+++ b/docs/pages/modules/tah-wfrp4e.md
@@ -4,6 +4,10 @@ title: Token Action HUD WFRP4e
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/Foundry-Workshop/token-action-hud-wfrp4e?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FFoundry-Workshop%2Ftoken-action-hud-wfrp4e%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2FFoundry-Workshop%2Ftoken-action-hud-wfrp4e%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
 **Author:** [Forien](https://foundryvtt.com/community/forien) ([discord](https://discord.gg/XkTFv8DRDc))  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/token-action-hud-wfrp4e) | [GitHub](https://github.com/Foundry-Workshop/token-action-hud-wfrp4e)
 

--- a/docs/pages/modules/tah-wfrp4e.md
+++ b/docs/pages/modules/tah-wfrp4e.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Token Action HUD WFRP4e
+parent: Fan-made Modules
+---
+
+**Author:** [Forien](https://foundryvtt.com/community/forien) ([discord](https://discord.gg/XkTFv8DRDc))  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/token-action-hud-wfrp4e) | [GitHub](https://github.com/Foundry-Workshop/token-action-hud-wfrp4e)
+
+![Token Action HUD](https://raw.githubusercontent.com/Foundry-Workshop/token-action-hud-wfrp4e/master/.github/assets/module-preview.gif)
+
+Token Action HUD WFRP4e is a repositionable HUD of actions for a selected token prepared specially for the WFRP4e system.
+
+Features:
+- Make rolls directly from the HUD instead of opening your character sheet.
+- Use items from the HUD or right-click an item to open its sheet.
+- Fix and Damage your Armour and Weapons.
+- Easily trigger Manual Effect Scripts.
+- Make quick Blind GM rolls.
+- Bypass Test Dialog.
+- Use Group Advantage Actions.

--- a/docs/pages/modules/unofficial-grimoire.md
+++ b/docs/pages/modules/unofficial-grimoire.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Unofficial Grimoire
+parent: Fan-made Modules
+---
+
+**Author:** [LeRatier Bretonnien](https://foundryvtt.com/community/leratier-bretonnien)  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-unofficial-grimoire) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-unofficial-grimoire)
+
+This module implements new spells from the "Unofficial Grimoire" : Petty Magic, Necromancy, Daemonology, Domains.

--- a/docs/pages/modules/unofficial-grimoire.md
+++ b/docs/pages/modules/unofficial-grimoire.md
@@ -4,6 +4,10 @@ title: Unofficial Grimoire
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/gitea/v/release/public/wfrp4e-unofficial-grimoire?gitea_url=https%3A%2F%2Fwww.uberwald.me%2Fgitea&style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-unofficial-grimoire%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fwww.uberwald.me%2Fgitea%2Fpublic%2Fwfrp4e-unofficial-grimoire%2Fraw%2Fbranch%2Fmaster%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
 **Author:** [LeRatier Bretonnien](https://foundryvtt.com/community/leratier-bretonnien)  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-unofficial-grimoire) | [Repository](https://www.uberwald.me/gitea/public/wfrp4e-unofficial-grimoire)
 

--- a/docs/pages/modules/warriors-of-salvation.md
+++ b/docs/pages/modules/warriors-of-salvation.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Warriors of Salvation
+parent: Fan-made Modules
+---
+
+**Author:** [artantares](https://foundryvtt.com/community/artantares)  
+**Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-warriors-of-salvation) | [GitHub](https://github.com/artptz/wfrp4e-divine)
+
+A Foundry module for WFRP 4E, basedon the homebrew content "Warriors of Salvation" written by Big Boss

--- a/docs/pages/modules/warriors-of-salvation.md
+++ b/docs/pages/modules/warriors-of-salvation.md
@@ -4,6 +4,10 @@ title: Warriors of Salvation
 parent: Fan-made Modules
 ---
 
+![Module Version](https://img.shields.io/github/v/release/artptz/wfrp4e-divine?style=for-the-badge)
+![Foundry Min Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2Fartptz%2Fwfrp4e-divine%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Min%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+![Foundry Verified Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fgithub.com%2Fartptz%2Fwfrp4e-divine%2Freleases%2Flatest%2Fdownload%2Fmodule.json&label=Foundry%20Verified&query=$.compatibility.verified&colorB=orange&style=for-the-badge)
+
 **Author:** [artantares](https://foundryvtt.com/community/artantares)  
 **Module:** [Foundry VTT](https://foundryvtt.com/packages/wfrp4e-warriors-of-salvation) | [GitHub](https://github.com/artptz/wfrp4e-divine)
 

--- a/docs/pages/premium.md
+++ b/docs/pages/premium.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Premium Content
+nav_order: 20
 ---
 
 There are four steps to take in acquiring and using Premium Content: Buying, Registering, Installing, and Activating

--- a/docs/pages/translation.md
+++ b/docs/pages/translation.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Translation
+nav_order: 50
 ---
 
 Complete translation of WFRP4e on Foundry is a multi-step involved process, each component detailed below. While some systems include translations in the system itself, I've determined the best avenue would be creating a standalone module introduce a translation. 

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Troubleshooting
+nav_order: 60
 ---
 
 {: .warning}


### PR DESCRIPTION
Introduced new pages documenting various fan-made modules for WFRP4e, such as Chat Commander, GM Toolkit, Fan-made Maps, and more. Additionally, updated navigation order for key sections like Active Effects, Macros, Translation, and Troubleshooting.