### PR TITLE
Fixes for Localized Corruption

### DIFF
--- a/src/documents/actor.js
+++ b/src/documents/actor.js
@@ -855,7 +855,7 @@ export default class ActorWFRP4e extends WarhammerActor
 
   async corruptionDialog(strength, skill) {
     skill = skill?.toLowerCase();
-    if (!["cool", "endurance"].includes(skill))
+    if (![game.i18n.localize("NAME.Cool").toLowerCase(), game.i18n.localize("NAME.Endurance").toLowerCase()].includes(skill))
     {
 
       skill = await foundry.applications.api.DialogV2.wait({
@@ -865,15 +865,15 @@ export default class ActorWFRP4e extends WarhammerActor
         content: `<p>${game.i18n.format("DIALOG.CorruptionContent", { name: this.name })}</p>`,
         buttons: [
           {
-            action : "endurance",
+            action : game.i18n.localize("NAME.Endurance"),
             label: game.i18n.localize("NAME.Endurance")
           },
           {
-            action : "cool",
+            action : game.i18n.localize("NAME.Cool"),
             label: game.i18n.localize("NAME.Cool")
           },
         ]
-      })
+      });
     }
 
     if (skill)

--- a/src/system/rolls/test-wfrp4e.js
+++ b/src/system/rolls/test-wfrp4e.js
@@ -694,7 +694,7 @@ export default class TestWFRP extends WarhammerTestBase {
 
     // Revert previous test if rerolled
     if (this.context.reroll || this.context.fortuneUsedAddSL) {
-      let previousFailed = this.context.previousResult.outcome == "failure";
+      let previousFailed = this.context.previousResult.outcome == "failure"
       switch (strength) {
         case game.i18n.localize("CORRUPTION.Minor").toLowerCase():
           if (previousFailed)

--- a/src/system/rolls/test-wfrp4e.js
+++ b/src/system/rolls/test-wfrp4e.js
@@ -677,18 +677,18 @@ export default class TestWFRP extends WarhammerTestBase {
 
         case game.i18n.localize("CORRUPTION.Moderate").toLowerCase():
         if (failed)
-          corruption += 2;
+          corruption += 2
         else if (this.result.SL < 2)
-          corruption += 1;
+          corruption += 1
         break;
 
         case game.i18n.localize("CORRUPTION.Major").toLowerCase():
         if (failed)
-          corruption += 3;
+          corruption += 3
         else if (this.result.SL < 2)
-          corruption += 2;
+          corruption += 2
         else if (this.result.SL < 4)
-          corruption += 1;
+          corruption += 1
         break;
     }
 
@@ -703,9 +703,9 @@ export default class TestWFRP extends WarhammerTestBase {
 
         case game.i18n.localize("CORRUPTION.Moderate").toLowerCase():
           if (previousFailed)
-            corruption -= 2;
+            corruption -= 2
           else if (this.context.previousResult.SL < 2)
-            corruption -= 1;
+            corruption -= 1
           break;
 
         case game.i18n.localize("CORRUPTION.Major").toLowerCase():

--- a/src/system/rolls/test-wfrp4e.js
+++ b/src/system/rolls/test-wfrp4e.js
@@ -670,19 +670,19 @@ export default class TestWFRP extends WarhammerTestBase {
     let failed = this.failed
     let corruption = 0 // Corruption GAINED
     switch (strength) {
-      case game.i18n.localize("CORRUPTION.Minor").toLowerCase():
+      case "minor":
         if (failed)
           corruption++;
         break;
 
-        case game.i18n.localize("CORRUPTION.Moderate").toLowerCase():
+        case "moderate":
         if (failed)
           corruption += 2
         else if (this.result.SL < 2)
           corruption += 1
         break;
 
-        case game.i18n.localize("CORRUPTION.Major").toLowerCase():
+        case "major":
         if (failed)
           corruption += 3
         else if (this.result.SL < 2)

--- a/src/system/rolls/test-wfrp4e.js
+++ b/src/system/rolls/test-wfrp4e.js
@@ -670,45 +670,45 @@ export default class TestWFRP extends WarhammerTestBase {
     let failed = this.failed
     let corruption = 0 // Corruption GAINED
     switch (strength) {
-      case "minor":
+      case game.i18n.localize("CORRUPTION.Minor").toLowerCase():
         if (failed)
           corruption++;
         break;
 
-        case "moderate":
+        case game.i18n.localize("CORRUPTION.Moderate").toLowerCase():
         if (failed)
-          corruption += 2
+          corruption += 2;
         else if (this.result.SL < 2)
-          corruption += 1
+          corruption += 1;
         break;
 
-        case "major":
+        case game.i18n.localize("CORRUPTION.Major").toLowerCase():
         if (failed)
-          corruption += 3
+          corruption += 3;
         else if (this.result.SL < 2)
-          corruption += 2
+          corruption += 2;
         else if (this.result.SL < 4)
-          corruption += 1
+          corruption += 1;
         break;
     }
 
     // Revert previous test if rerolled
     if (this.context.reroll || this.context.fortuneUsedAddSL) {
-      let previousFailed = this.context.previousResult.outcome == "failure"
+      let previousFailed = this.context.previousResult.outcome == "failure";
       switch (strength) {
-        case "minor":
+        case game.i18n.localize("CORRUPTION.Minor").toLowerCase():
           if (previousFailed)
             corruption--;
           break;
 
-        case "moderate":
+        case game.i18n.localize("CORRUPTION.Moderate").toLowerCase():
           if (previousFailed)
-            corruption -= 2
+            corruption -= 2;
           else if (this.context.previousResult.SL < 2)
-            corruption -= 1
+            corruption -= 1;
           break;
 
-        case "major":
+        case game.i18n.localize("CORRUPTION.Major").toLowerCase():
           if (previousFailed)
             corruption -= 3
           else if (this.context.previousResult.SL < 2)


### PR DESCRIPTION
A couple of fixes for Corruption when using a translation.

- corruptionDialog now looks for the localized versions of cool and endurance.
- Now re-rolls look for the localized strength, like the original roll.

For tanslators: If you want that lowercased strengths can be used (for the chat command, for example), you have to change these lines in the lang file.
```
    "minor": "Minor",
    "moderate": "Moderate",
    "major": "Major",
```
Spanish example:
```
    "menor": "Menor",
    "moderada": "Moderada",
    "mayor": "Mayor",
```
Or you can add them, as you prefer.