### PR TITLE
Update Homebrew Settings Scope to World

### DIFF
--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -66,7 +66,7 @@ export default function() {
 
     game.settings.register("wfrp4e", "homebrew", {
       name: "Hombrew Settings",
-      scope: "client",
+      scope: "world",
       config: false,
       type: HomebrewConfig.schema
     });


### PR DESCRIPTION
Homebrew settings are being saved on the client side, preventing the GM adjustments from propagating to all players.