### PR TITLE
Condition Tweaks

### DIFF
--- a/src/system/combat.js
+++ b/src/system/combat.js
@@ -288,7 +288,7 @@ export default class CombatHelpersWFRP {
             for (let cond of conditions) {
                 // I swear to god whoever thought it was a good idea for these conditions to reduce every *other* round...
                 if (cond.conditionId == "deafened" || cond.conditionId == "blinded" && Number.isNumeric(cond.flags.wfrp4e.roundReceived)) {
-                    if ((combat.round - 1) % 2 == cond.flags.wfrp4e.roundReceived % 2) {
+                    if ((combat.round) % 2 == cond.flags.wfrp4e.roundReceived % 2) {
                         await turn.actor.removeCondition(cond.conditionId)
                         removedConditions.push(
                             game.i18n.format("CHAT.RemovedConditions", {

--- a/src/system/config-wfrp4e.js
+++ b/src/system/config-wfrp4e.js
@@ -2101,7 +2101,19 @@ WFRP4E.PrepareSystemItems = function() {
                         trigger: "prePrepareData",
                         label: "Half Movement",
                         script: `args.actor.system.details.move.value /= 2`
-                    }
+                    },
+                    {
+                        trigger: "endRound",
+                        label: "Roll to remove Stunned",
+                        script: `
+const test = await this.actor.setupSkill(game.i18n.localize("NAME.Endurance"), {fields: {difficulty: "challenging"}, skipTargets: true, appendTitle :  \` - \${this.effect.name}\`, context: {success: "Removed SL + 1 Conditions.", failure: "Failed to remove Conditions."}});
+await test.roll();
+if (test.succeeded) {
+  const toRemove = 1 + Number(test.result.SL);
+  this.actor.removeCondition("stunned", toRemove);
+}
+                    `,
+                    },
                     // { // Not sure what to do about this
                     //     trigger: "dialog",
                     //     label : "Bonus to Melee Attacks",

--- a/src/system/config-wfrp4e.js
+++ b/src/system/config-wfrp4e.js
@@ -1343,6 +1343,18 @@ WFRP4E.PrepareSystemItems = function() {
                                         this.item.updateSource({name : this.item.name + " (" + name + ")" })
                                     }
                                     `
+                                },
+                                {
+                                    trigger: "endRound",
+                                    label: "Roll to remove Fear",
+                                    script: `
+                                        const test = await this.actor.setupExtendedTest(this.effect.item, {
+                                            fields: {difficulty: "challenging"}, 
+                                            skipTargets: true, 
+                                            appendTitle :  \` - \${this.effect.name}\`, 
+                                        });
+                                        await test.roll();
+                                    `,
                                 }
                             ]
                         }


### PR DESCRIPTION
- Fixed `Blinded` and `Deafened` being removed _the same round_ they were applied. They now correctly start going down on the second round and then every other round. So if 3 Blinded were applied on Round 2, they will go off in Rounds 3, 5 and 7. 
- `Stunned` Condition now automatically prompts Endurance Skill Dialog at the End of Round
- `Fear` Extended Test now automatically prompts Extended Test Dialog with the owning Item at the End of Round