### PR TITLE
Add Critical Deflection

### DIFF
--- a/src/documents/actor.js
+++ b/src/documents/actor.js
@@ -737,6 +737,10 @@ export default class ActorWFRP4e extends WarhammerActor
         updateMsg += `<br><a data-action="clickTable" class="action-link critical-roll" data-modifier="-20" data-table = "crit${opposedTest.result.hitloc.value}" ><i class='fas fa-list'></i> ${game.i18n.localize("Critical")} (-20)</a>`
       else
         updateMsg += `<br><a data-action="clickTable" class="action-link critical-roll" data-table = "crit${opposedTest.result.hitloc.value}" ><i class='fas fa-list'></i> ${game.i18n.localize("Critical")}</a>`
+
+      if (modifiers.ap.nonmetal > 0 || modifiers.ap.metal > 0) {
+        updateMsg += ` / <a class="action-link" data-action="applyHack">${game.i18n.localize('CHAT.CriticalDeflection')}</a>`
+      }
     }
     if (hack)
     {

--- a/src/model/message/opposed-result.js
+++ b/src/model/message/opposed-result.js
@@ -72,6 +72,7 @@ export class OpposedTestMessage extends WarhammerMessageModel
     static async onApplyHack(ev)
     {
         let opposedTest = this.opposedTest;
+        const type = ev.target.innerText;
   
       if (!opposedTest.defenderTest.actor.isOwner)
         return ui.notifications.error("ErrorHackPermission", {localize : true})
@@ -80,11 +81,11 @@ export class OpposedTestMessage extends WarhammerMessageModel
       let armour = opposedTest.defenderTest.actor.itemTypes.armour.filter(i => i.system.isEquipped && i.system.protects[loc] && i.system.currentAP[loc] > 0)
       if (armour.length)
       {
-        let chosen = await ItemDialog.create(armour, 1, "Choose Armour to damage");
+        let chosen = await ItemDialog.create(armour, 1, {text : "Choose Armour to damage", title : type});
         if (chosen[0])
         {
           chosen[0].system.damageItem(1, [loc])
-          ChatMessage.create({content: `<p>1 Damage applied to @UUID[${chosen[0].uuid}]{${chosen[0].name}} (Hack)</p>`, speaker : ChatMessage.getSpeaker({actor : opposedTest.attackerTest.actor})})
+          ChatMessage.create({content: `<p>1 Damage applied to @UUID[${chosen[0].uuid}]{${chosen[0].name}} (${type})</p>`, speaker : ChatMessage.getSpeaker({actor : opposedTest.attackerTest.actor})})
         }
       }
       else 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -856,6 +856,7 @@
     "CHAT.DamageApplied" : "Damage Applied",
     "CHAT.ApplyDamageBasic" : "@DAMAGE damage applied to <b>{name}</b>",
     "CHAT.ApplyHack" : "Apply Hack",
+    "CHAT.CriticalDeflection" : "Critical Deflection",
     "CHAT.DamageShield" : "Shield",
     "CHAT.CriticalsNullified" : "Criticals Nullified",
     "CHAT.DamageAP" : "Damage 1 AP on",

--- a/style/foundry/_general.scss
+++ b/style/foundry/_general.scss
@@ -6,6 +6,14 @@ body {
         background: url(/ui/parchment.jpg) repeat
     }
 
+    .critical {
+        color: green;
+    }
+
+    .fumble {
+         color: darkred;
+     }
+
     .action-link {
         @include content-link;
 


### PR DESCRIPTION
Adds Critical Deflection mechanic as option next to Critical table wound.
Uses existing Hack mechanic.
![image](https://github.com/user-attachments/assets/55582e9e-419e-4e9a-a496-ce3081512aa6)
Also fixes critical roll not being colored in message.
![image](https://github.com/user-attachments/assets/37ffb195-95b3-4f45-9670-4277309a3e01)