### PR TITLE
Increase quantity of item on purchase

### DIFF
--- a/src/model/message/posted-item.js
+++ b/src/model/message/posted-item.js
@@ -83,8 +83,26 @@ export class PostedItemMessageModel extends WarhammerMessageModel {
     let paid = await game.wfrp4e.market.handlePlayerPayment({payString : game.wfrp4e.market.amountToString(this.itemData.system.price), itemData : this.itemData});
     for(let actor of paid)
     {
-      await actor.createEmbeddedDocuments("Item", [this.itemData], {fromMessage: this.parent.id})
-      ui.notifications.notify(game.i18n.format("MARKET.ItemAdded", { item: this.itemData.name, actor : actor.name })) 
+      const hasItem = actor.itemTypes[this.itemData.type].find(i => i.name === this.itemData.name
+          && i._stats.compendiumSource === this.itemData._stats.compendiumSource
+          && i.system.encumbrance.value === this.itemData.system.encumbrance.value
+          && JSON.stringify(i.system.price) === JSON.stringify(this.itemData.system.price)
+          && JSON.stringify(i.system.description) === JSON.stringify(this.itemData.system.description)
+          && JSON.stringify(i.system.availability) === JSON.stringify(this.itemData.system.availability)
+          && JSON.stringify(i.system.flaws) === JSON.stringify(this.itemData.system.flaws)
+          && JSON.stringify(i.system.qualities) === JSON.stringify(this.itemData.system.qualities)
+          && JSON.stringify(i.system.trappingType) === JSON.stringify(this.itemData.system.trappingType)
+          && JSON.stringify(i.system.damageToItem) === JSON.stringify(this.itemData.system.damageToItem));
+      if(hasItem) {
+        await actor.updateEmbeddedDocuments("Item", [{
+          _id : hasItem.id,
+          "system.quantity.value" : hasItem.system.quantity.value + 1,
+        }], {fromMessage: this.parent.id});
+        ui.notifications.notify(game.i18n.format("MARKET.ItemAppended", { item: this.itemData.name, actor : actor.name, quantity: hasItem.system.quantity.value }));
+      } else {
+        await actor.createEmbeddedDocuments("Item", [this.itemData], {fromMessage: this.parent.id});
+        ui.notifications.notify(game.i18n.format("MARKET.ItemAdded", { item: this.itemData.name, actor : actor.name }));
+      }
     }
   }
 

--- a/src/model/message/posted-item.js
+++ b/src/model/message/posted-item.js
@@ -86,13 +86,13 @@ export class PostedItemMessageModel extends WarhammerMessageModel {
       const hasItem = actor.itemTypes[this.itemData.type].find(i => i.name === this.itemData.name
           && i._stats.compendiumSource === this.itemData._stats.compendiumSource
           && i.system.encumbrance.value === this.itemData.system.encumbrance.value
-          && JSON.stringify(i.system.price) === JSON.stringify(this.itemData.system.price)
-          && JSON.stringify(i.system.description) === JSON.stringify(this.itemData.system.description)
-          && JSON.stringify(i.system.availability) === JSON.stringify(this.itemData.system.availability)
-          && JSON.stringify(i.system.flaws) === JSON.stringify(this.itemData.system.flaws)
-          && JSON.stringify(i.system.qualities) === JSON.stringify(this.itemData.system.qualities)
-          && JSON.stringify(i.system.trappingType) === JSON.stringify(this.itemData.system.trappingType)
-          && JSON.stringify(i.system.damageToItem) === JSON.stringify(this.itemData.system.damageToItem));
+          && foundry.utils.objectsEqual(i.system.price, this.itemData.system.price)
+          && foundry.utils.objectsEqual(i.system.description, this.itemData.system.description)
+          && foundry.utils.objectsEqual(i.system.availability, this.itemData.system.availability)
+          && foundry.utils.objectsEqual(i.system.flaws, this.itemData.system.flaws)
+          && foundry.utils.objectsEqual(i.system.qualities, this.itemData.system.qualities)
+          && foundry.utils.objectsEqual(i.system.trappingType, this.itemData.system.trappingType)
+          && foundry.utils.objectsEqual(i.system.damageToItem, this.itemData.system.damageToItem));
       if(hasItem) {
         await actor.updateEmbeddedDocuments("Item", [{
           _id : hasItem.id,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1133,6 +1133,7 @@
     "MARKET.NotifyNoActor": "No Character is selected or associated with the current user",
     "MARKET.NotifyUserMustBePlayer": "Must be a player to click on PAY",
     "MARKET.ItemAdded" : "{item} added to {actor}",
+    "MARKET.ItemAppended" : "{actor} now has {quantity} {item}s",
     "Post Quantity" : "Post Quantity",
 
     "WFRP4E.TrappingType.Weapon" : "Weapons",


### PR DESCRIPTION
If actor has said item in their inventory then just increase the quantity instead of adding new instance.
Works with items at 0 quantity.
Performance tested with 10x slow CPU and actor with 100 items of type and the search is usually completed in 0.4ms