### PR TITLE
fix: Engaged status now no longer causes error on attack

### DIFF
--- a/src/apps/roll-dialog/attack-dialog.js
+++ b/src/apps/roll-dialog/attack-dialog.js
@@ -68,7 +68,7 @@ export default class AttackDialog extends SkillDialog
         {
             this.fields.modifier -= 20;
             this.tooltips.add("modifier", -20, game.i18n.localize("EFFECT.ShootingAtEngagedTarget"));
-            this.options.engagedModifier = -20;
+            this.context.engagedModifier = -20;
         }
 
 


### PR DESCRIPTION
Fixes #2543
Was caused by this.options object being not extensible.
Checked if scenario engagedModifier was used by is working now.
![image](https://github.com/user-attachments/assets/8a530d2f-88b2-46da-8d83-bdb554125805)
