### PR TITLE
Restore feedback on Damaged Armour

### DIFF
--- a/static/templates/sheets/partials/armour-location.hbs
+++ b/static/templates/sheets/partials/armour-location.hbs
@@ -16,7 +16,7 @@
               <img src="{{this.img}}">
               <a class="label">{{this.name}}</a>
             </div>
-            <a class="small prevent-context" data-action="stepProperty" data-reversed="true" data-path="system.APdamage.{{../loc}}" data-tooltip="{{localize 'SHEET.ArmourCurrent'}}: {{lookup this.system.currentAP ../loc}} {{localize 'SHEET.ArmourMax'}}: {{lookup this.system.AP ../loc}} ({{lookup this.system.APdamage ../loc}} {{localize 'Damage'}})" class="ap-value {{#if (lookup this.system.APdamage ../loc)}}item-damaged{{/if}}">{{lookup this.system.currentAP ../loc}}</a>
+            <a class="small prevent-context ap-value {{#if (lookup this.system.APdamage ../loc)}}item-damaged{{/if}}" data-action="stepProperty" data-reversed="true" data-path="system.APdamage.{{../loc}}" data-tooltip="{{localize 'SHEET.ArmourCurrent'}}: {{lookup this.system.currentAP ../loc}} {{localize 'SHEET.ArmourMax'}}: {{lookup this.system.AP ../loc}} ({{lookup this.system.APdamage ../loc}} {{localize 'Damage'}})">{{lookup this.system.currentAP ../loc}}</a>
           </div>
           <div class="item-property-row">
 

--- a/style/sheets/actors/_actor.scss
+++ b/style/sheets/actors/_actor.scss
@@ -237,6 +237,10 @@
                 background: radial-gradient(circle, rgba(221,221,221,0) 0%, rgba(27,143,35,1) 100%);
             }
         }
+
+        .item-damaged {
+            color: darkred;
+        }
     }
     .dropdown-content {
         .tags {


### PR DESCRIPTION
Implements #2552 by restoring 8.* styling for the Armour table

![image](https://github.com/user-attachments/assets/2e9fd456-edf4-4e0e-9991-080f87b5bd95)