### PR TITLE
Fix typo in shared SOC ship criticals script

### DIFF
--- a/scripts/6oSs8qKFNFz2lSmh.js
+++ b/scripts/6oSs8qKFNFz2lSmh.js
@@ -1,2 +1,2 @@
-if (args.actorsystem.details.move.sail.value > 0)
+if (args.actor.system.details.move.sail.value > 0)
   args.actor.system.details.move.sail.value = 0;


### PR DESCRIPTION
Applies to SOC Vehicle > Critical > Rigging items: 
- Mast Shattered
- Ruined Sail
- Yard Snapped