### PR TITLE
fix(2562): Fixes styling on max encumbrance input

### DIFF
--- a/style/sheets/actors/tabs/_trappings.scss
+++ b/style/sheets/actors/tabs/_trappings.scss
@@ -42,7 +42,9 @@
             display: flex;
             justify-content: space-between;
             padding: 5px;
-            border-bottom: 1px solid var(--color-cool-3)
+            border-bottom: 1px solid var(--color-cool-3);
+            min-height: 2rem;
+            align-items: center;
         }
 
         .counter {
@@ -51,7 +53,7 @@
 
         .status {
             position: absolute;
-            top: 2.0rem;
+            top: 2.5rem;
             left: 5px;
         }
 

--- a/style/theme/_actor.scss
+++ b/style/theme/_actor.scss
@@ -252,6 +252,20 @@
             .header {
                 @include shadowed(#6b3a0f87);
                 border-color: var(--color-faded);
+
+                .counter {
+                    input {
+                        color: var(--color-grey1);
+                        border: 1px solid var(--attribute-border);
+                        border-radius: 0px;
+                        text-align: center;
+                        background-color: var(--attribute-input);
+                        padding: 0px;
+                        height: 1rem;
+                        width: 3rem;
+                        line-height: 1rem;
+                    }
+                }
             }
 
             .bar {


### PR DESCRIPTION
I'm not entirely happy with this because of added input stylings in the actor.scss but using existing inputs would require changing entire header to use attribute-box or form-group and I didn't want to go so far with UI changes.
Current solution maintains the look for the auto calculation while providing usable input for manual users.


Before:
<img width="1242" height="88" alt="image" src="https://github.com/user-attachments/assets/c11d9d6c-85c9-413b-843f-003e52d29b90" />
After:
<img width="1163" height="67" alt="image" src="https://github.com/user-attachments/assets/35efcacf-b270-4691-b47d-00cf34e0bf63" />
