### PR TITLE
fix: Prevent setup of Prayer test from rolling

### DIFF
--- a/src/documents/actor.js
+++ b/src/documents/actor.js
@@ -198,7 +198,7 @@ export default class ActorWFRP4e extends WarhammerActor
    */
   async setupPrayer(prayer, context = {}, options) 
   {
-    return this._setupTest(PrayerDialog, PrayerTest, prayer, context, options, options, false)
+    return this._setupTest(PrayerDialog, PrayerTest, prayer, context, options, false)
   }
 
   /**


### PR DESCRIPTION
Fixes issue with Prayer tests being rolled twice.

setupTest interface is like this
`_setupTest(dialogClass, testClass, data, context = {}, options={}, roll = true, sendToChat=true)`
so additional option was causing a roll as objects are truthy.