### PR TITLE
fix: Restore template placement to Blast quality

### DIFF
--- a/src/system/config-wfrp4e.js
+++ b/src/system/config-wfrp4e.js
@@ -2419,7 +2419,7 @@ if (test.succeeded) {
                 scriptData : [{
                     label : "Blast",
                     trigger : "rollWeaponTest",
-                    script : "if (args.test.succeeded) args.test.result.other.push(`<a class='aoe-template' data-type='radius'><i class='fas fa-ruler-combined'></i>${this.item.properties.qualities.blast.value} yard Blast</a>`)",
+                    script : "if (args.test.succeeded) args.test.result.other.push(`<a data-action='placeTemplate' class='aoe-template' data-type='radius'><i class='fas fa-ruler-combined'></i>${this.item.properties.qualities.blast.value} yard Blast</a>`)",
                 }]
             }
         },


### PR DESCRIPTION
Fixes #2583 
Data-action already existed for it but just wasn't hooked up to the message.

<img width="968" height="685" alt="image" src="https://github.com/user-attachments/assets/c7a87ae4-9796-4c35-9051-5d6707570872" />