### PR TITLE
fix: Add hr style in journal content

### DIFF
--- a/style/theme/_journal.scss
+++ b/style/theme/_journal.scss
@@ -1,4 +1,5 @@
 @use "./mixins" as *;
+@use "../mixins/border" as *;
 
 .application.journal-entry:not(.no-theme) {
 
@@ -143,6 +144,9 @@
     .journal-page-content {
         @include editor-text;
 
+        hr {
+            @include gradient-border;
+        }
     }
 
     .edit-container button {


### PR DESCRIPTION
Fixes #2571 

Now horizontal rule is visible in both editor and journal.

<img width="948" height="648" alt="image" src="https://github.com/user-attachments/assets/5bb47e83-688e-4cbe-9f25-047b975a41dc" />
