### PR TITLE
fix: -1 Fel per 2 teeth lost

### DIFF
--- a/scripts/eAtqyBd1HsDWuBuI.js
+++ b/scripts/eAtqyBd1HsDWuBuI.js
@@ -1,1 +1,1 @@
-this.actor.system.characteristics.fel.modifier -= parseInt(this.item.system.location.value) || 1
+this.actor.system.characteristics.fel.modifier += Math.round(-parseInt(this.item.system.location.value)/2) || -1


### PR DESCRIPTION
Hi,

My character just lost a bunch of teeth and I noticed the script was too harsh on the Fel malus, compared to what the rulebook says.
This is the fix I used in the campaign.

I let the "-1" when there is no tooth count but I'm not sure if this is the right value (if no count means 1 tooth, malus should be 0)

Thanks for letting players (who are proficient in JS) fix scripts on the fly BTW, my DM was glad :)