### PR TITLE
Fix creating Fear test when actor has no Cool skill

### DIFF
--- a/src/documents/actor.js
+++ b/src/documents/actor.js
@@ -1102,6 +1102,11 @@ export default class ActorWFRP4e extends WarhammerActor
     fear.system.SL.target = value;
 
     foundry.utils.setProperty(fear, "flags.wfrp4e.fearName", name)
+    
+    let coolSkill = this.itemTags["skill"].find(i => i.name == game.i18n.localize("NAME.Cool")) 
+    if (!coolSkill) {
+      foundry.utils.setProperty(fear, "system.test.value", game.i18n.localize("CHAR.WP"))
+    }
 
     return this.createEmbeddedDocuments("Item", [fear], {condition: true}).then(items => {
       this.setupExtendedTest(items[0], {appendTitle : ` - ${items[0].name}`});


### PR DESCRIPTION
When Actor doesn't have Cool Skill applying Fear (e.g. from `/fear` command) fails with error saying that Cool skill wasn't found.

Apparently this is because Fear effect item which is being duplicated from config has hardcoded "Cool" as test.

This fix checks for existence of Cool Skill and if needed updates duplicated Fear Effect to use Willpower.