### PR TITLE
Dead overlay

### DIFF
--- a/src/system/config-wfrp4e.js
+++ b/src/system/config-wfrp4e.js
@@ -2373,6 +2373,11 @@ if (test.succeeded) {
                     value : null,
                     numbered: false
                 },
+            },
+            flags: {
+                core: {
+                    overlay: true
+                }
             }
         }
     ]


### PR DESCRIPTION
Similar to [this PR for Imperium Maledictum](https://github.com/moo-man/ImpMal-FoundryVTT/pull/202), this one makes the Dead icon much more noticeable in the tokens.

![Dead Overlay](https://github.com/user-attachments/assets/b65052ed-562c-4802-829b-d4526efb0c7b)
