### PR TITLE
Migrate to native DsN v6 integration

### DIFF
--- a/src/model/message/opposed-result.js
+++ b/src/model/message/opposed-result.js
@@ -26,6 +26,9 @@ export class OpposedTestMessage extends WarhammerMessageModel
         user: game.user.id,
         type : "opposed",
         content: html,
+        flags : {
+          "dice-so-nice" : { linkedTo : handler.data.defenderMessageId }
+        },
         system : {
           opposedTestData: opposeData,
           handlerId: handler.message.id,

--- a/src/system/opposed-handler.js
+++ b/src/system/opposed-handler.js
@@ -137,7 +137,7 @@ export default class OpposedHandler {
 
     // Ranged weapon opposed tests automatically lose no matter what if the test itself fails
     if (this.attackerTest.item && this.attackerTest.item.isRanged && this.attackerTest.failed) {
-      await ChatMessage.create({ speaker: this.attackerMessage.speaker, content: game.i18n.localize("OPPOSED.FailedRanged") })
+      await ChatMessage.create({ speaker: this.attackerMessage.speaker, content: game.i18n.localize("OPPOSED.FailedRanged"), flags: {"dice-so-nice": {linkedTo: this.data.attackerMessageId}} })
       return;
     }
     let chatData = {
@@ -148,6 +148,7 @@ export default class OpposedHandler {
         whisper: this.options.whisper,
         blind: this.options.blind,
         author : getActiveDocumentOwner(defender?.actor)?.id,
+        flags : { "dice-so-nice" : { linkedTo : this.data.attackerMessageId }},
         system : {
           opposedData : this.data
         }

--- a/src/system/rolls/test-wfrp4e.js
+++ b/src/system/rolls/test-wfrp4e.js
@@ -970,50 +970,6 @@ export default class TestWFRP extends WarhammerTestBase {
 
 
 
-  /**
-   * Add support for the Dice So Nice module
-   * @param {Object} roll 
-   * @param {String} rollMode 
-   */
-  async _showDiceSoNice(roll, rollMode, speaker) {
-    if (game.modules.get("dice-so-nice") && game.modules.get("dice-so-nice").active) {
-
-      if (game.settings.get("dice-so-nice", "hideNpcRolls")) {
-        let actorType = null;
-        if (speaker.actor)
-          actorType = game.actors.get(speaker.actor).type;
-        else if (speaker.token && speaker.scene)
-          actorType = game.scenes.get(speaker.scene).tokens.get(speaker.token).actor.type;
-        if (actorType != "character")
-          return;
-      }
-
-      let whisper = null;
-      let blind = false;
-      let sync = true;
-      switch (rollMode) {
-        case "blindroll": //GM only
-          blind = true;
-        case "gmroll": //GM + rolling player
-          let gmList = game.users.filter(user => user.isGM);
-          let gmIDList = [];
-          gmList.forEach(gm => gmIDList.push(gm.id));
-          whisper = gmIDList;
-          break;
-        case "selfroll":
-          sync = false;
-          break;
-        case "roll": //everybody
-          let userList = game.users.filter(user => user.active);
-          let userIDList = [];
-          userList.forEach(user => userIDList.push(user.id));
-          whisper = userIDList;
-          break;
-      }
-      await game.dice3d.showForRoll(roll, game.user, sync, whisper, blind);
-    }
-  }
-
   // @@@@@@@ Overcast functions placed in root class because it is used by both spells and prayers @@@@@@@
   async _overcast(choice) {
     let overcastData = this.result.overcast

--- a/src/system/rolls/test-wfrp4e.js
+++ b/src/system/rolls/test-wfrp4e.js
@@ -868,8 +868,8 @@ export default class TestWFRP extends WarhammerTestBase {
   async rollDices() {
     if (isNaN(this.preData.roll)) {
       let roll = await new Roll("1d100").roll();
-      await this._showDiceSoNice(roll, this.context.chatOptions.rollMode || "roll", this.context.speaker);
       this.result.roll = roll.total;
+      this.result.rollObject = roll;
     }
     else
       this.result.roll = this.preData.roll;
@@ -899,8 +899,8 @@ export default class TestWFRP extends WarhammerTestBase {
 
     this.result.breakdown.formatted = this.formatBreakdown()
 
-    if (game.modules.get("dice-so-nice") && game.modules.get("dice-so-nice").active && messageData.sound?.includes("dice"))
-      messageData.sound = undefined;
+    if (this.result.rollObject)
+      messageData.rolls = [this.result.rollObject];
 
     let templateData = {
       test: this,


### PR DESCRIPTION
Hey! 

Dice So Nice v6 is coming soon, and with it a feature that will finally allow WFRP multi-message flow to be supported. Now you can link messages to its "primary" message source, that contains the roll.

This means:
- No more direct call to the Dice So Nice API, so no risk of breaking change
- Native integration with all Dice So Nice features (disabling NPC rolls, per-actor dice customization and more) 

I hope I remembered all the possible automated multi-message flows, let me know if I missed some 

Do not merge until Dice So Nice v6 is released! I wanted to make sure the feature worked and give you the time to review the changes. I'll post a new message when v6 is released.