### PR TITLE
Morrslieb FXMaster Greener

### DIFF
--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -494,8 +494,8 @@ export default function() {
         color: { value:"#4cb53a", apply: true },
         gamma: 1.0,
         contrast: 1.0,
-        brightness: 1.0,
-        saturation: 0.2
+        brightness: 0.6,
+        saturation: 0.8
     }
 
     CONFIG.fontDefinitions.CaslonAntique = {editor : true, fonts : []}


### PR DESCRIPTION
The green Morrslieb effect is too pale when using FXMaster module. With this PR the effect is more similar to the effect when the module is not present.
<img width="1352" height="606" alt="Morrslieb" src="https://github.com/user-attachments/assets/de7539da-e5cc-4653-8655-a310b58d879a" />

Tested in v13 and v14 (the pic is v14).
Latest version of system (9.5.4) and module (8.0.5).