### PR TITLE
Spellcaster armour

### DIFF
--- a/src/apps/homebrew-settings.js
+++ b/src/apps/homebrew-settings.js
@@ -24,6 +24,7 @@ export default class HomebrewConfig extends WHFormApplication
     static #schema = new foundry.data.fields.SchemaField({
 
         channelingNegativeSLTests : new foundry.data.fields.BooleanField({label : "SETTINGS.ChannelingNegativeSL", hint : "SETTINGS.ChannelingNegativeSLHint"}),
+        spellcasterArmourPenalties : new foundry.data.fields.BooleanField({initial : true, label : "SETTINGS.SpellcasterArmourPenalties", hint : "SETTINGS.SpellcasterArmourPenaltiesHint"}),
         advantageBonus : new foundry.data.fields.NumberField({initial : 10, label : "SETTINGS.AdvantageBonus", hint : "SETTINGS.AdvantageBonusHint"}),
         uiaCritsMod : new foundry.data.fields.NumberField({initial: 10, label : "SETTINGS.UIACritsMod", hint : "SETTINGS.UIACritsModHint"}),
         partialChannelling : new foundry.data.fields.BooleanField({label : "SETTINGS.PartialChannelling", hint : "SETTINGS.PartialChannellingHint"}),

--- a/src/apps/roll-dialog/cast-dialog.js
+++ b/src/apps/roll-dialog/cast-dialog.js
@@ -1,5 +1,6 @@
 import CharacteristicDialog from "./characteristic-dialog";
 import SkillDialog from "./skill-dialog";
+import CastTest from "../../system/rolls/cast-test.js";
 
 export default class CastDialog extends SkillDialog {
 
@@ -81,6 +82,37 @@ export default class CastDialog extends SkillDialog {
         data.itemData = spell.toObject();
 
         return dialogData;
+    }
+
+    computeFields() {
+        super.computeFields();
+        let talentMetal = this.actor.has("Arcane Magic (Metal)", "talent");
+        let talentBeasts = this.actor.has("Arcane Magic (Beasts)", "talent");
+        let wearingArmour = {
+            head: 0,
+            lArm: 0,
+            rArm: 0,
+            lLeg: 0,
+            rLeg: 0,
+            body: 0,
+        };
+        let debuff = 0;
+        for (let a of this.actor.itemTags["armour"].filter(i => i.isEquipped)) {
+            if ((a.system.isMetal && !talentMetal) || (a.system.isLeather && !talentBeasts)) {
+                const currentAP = a.system.currentAP;
+                for (let loc in currentAP) {
+                    wearingArmour[loc] = currentAP[loc] + wearingArmour[loc];
+                }
+            }
+        }
+        for (let loc in wearingArmour) {
+            debuff = Math.max(debuff, wearingArmour[loc]);
+        }
+
+        if (debuff > 0) {
+            this.fields.slBonus += -debuff;
+            this.tooltips.add("slBonus", -debuff, game.i18n.localize("SHEET.SpellcasterArmourPenalties"));
+        }
     }
 
     _getSubmissionData()

--- a/src/apps/roll-dialog/cast-dialog.js
+++ b/src/apps/roll-dialog/cast-dialog.js
@@ -1,6 +1,6 @@
 import CharacteristicDialog from "./characteristic-dialog";
 import SkillDialog from "./skill-dialog";
-import CastTest from "../../system/rolls/cast-test.js";
+import { applySpellcasterArmourPenalty } from "./spellcaster-armour-penalty.js";
 
 export default class CastDialog extends SkillDialog {
 
@@ -86,33 +86,7 @@ export default class CastDialog extends SkillDialog {
 
     computeFields() {
         super.computeFields();
-        let talentMetal = this.actor.has("Arcane Magic (Metal)", "talent");
-        let talentBeasts = this.actor.has("Arcane Magic (Beasts)", "talent");
-        let wearingArmour = {
-            head: 0,
-            lArm: 0,
-            rArm: 0,
-            lLeg: 0,
-            rLeg: 0,
-            body: 0,
-        };
-        let debuff = 0;
-        for (let a of this.actor.itemTags["armour"].filter(i => i.isEquipped)) {
-            if ((a.system.isMetal && !talentMetal) || (a.system.isLeather && !talentBeasts)) {
-                const currentAP = a.system.currentAP;
-                for (let loc in currentAP) {
-                    wearingArmour[loc] = currentAP[loc] + wearingArmour[loc];
-                }
-            }
-        }
-        for (let loc in wearingArmour) {
-            debuff = Math.max(debuff, wearingArmour[loc]);
-        }
-
-        if (debuff > 0) {
-            this.fields.slBonus += -debuff;
-            this.tooltips.add("slBonus", -debuff, game.i18n.localize("SHEET.SpellcasterArmourPenalties"));
-        }
+        applySpellcasterArmourPenalty(this.actor, this.fields, this.tooltips);
     }
 
     _getSubmissionData()

--- a/src/apps/roll-dialog/channelling-dialog.js
+++ b/src/apps/roll-dialog/channelling-dialog.js
@@ -105,6 +105,37 @@ export default class ChannellingDialog extends SkillDialog {
         return dialogData;
     }
 
+    computeFields() {
+        super.computeFields();
+        let talentMetal = this.actor.has("Arcane Magic (Metal)", "talent");
+        let talentBeasts = this.actor.has("Arcane Magic (Beasts)", "talent");
+        let wearingArmour = {
+            head: 0,
+            lArm: 0,
+            rArm: 0,
+            lLeg: 0,
+            rLeg: 0,
+            body: 0,
+        };
+        let debuff = 0;
+        for (let a of this.actor.itemTags["armour"].filter(i => i.isEquipped)) {
+            if ((a.system.isMetal && !talentMetal) || (a.system.isLeather && !talentBeasts)) {
+                const currentAP = a.system.currentAP;
+                for (let loc in currentAP) {
+                    wearingArmour[loc] = currentAP[loc] + wearingArmour[loc];
+                }
+            }
+        }
+        for (let loc in wearingArmour) {
+            debuff = Math.max(debuff, wearingArmour[loc]);
+        }
+
+        if (debuff > 0) {
+            this.fields.slBonus += -debuff;
+            this.tooltips.add("slBonus", -debuff, game.i18n.localize("SHEET.SpellcasterArmourPenalties"));
+        }
+    }
+
     _getSubmissionData()
     {
         let data = super._getSubmissionData();

--- a/src/apps/roll-dialog/channelling-dialog.js
+++ b/src/apps/roll-dialog/channelling-dialog.js
@@ -1,5 +1,6 @@
 import ChannelTest from "../../system/rolls/channel-test";
 import SkillDialog from "./skill-dialog";
+import { applySpellcasterArmourPenalty } from "./spellcaster-armour-penalty.js";
 
 export default class ChannellingDialog extends SkillDialog {
 
@@ -107,33 +108,7 @@ export default class ChannellingDialog extends SkillDialog {
 
     computeFields() {
         super.computeFields();
-        let talentMetal = this.actor.has("Arcane Magic (Metal)", "talent");
-        let talentBeasts = this.actor.has("Arcane Magic (Beasts)", "talent");
-        let wearingArmour = {
-            head: 0,
-            lArm: 0,
-            rArm: 0,
-            lLeg: 0,
-            rLeg: 0,
-            body: 0,
-        };
-        let debuff = 0;
-        for (let a of this.actor.itemTags["armour"].filter(i => i.isEquipped)) {
-            if ((a.system.isMetal && !talentMetal) || (a.system.isLeather && !talentBeasts)) {
-                const currentAP = a.system.currentAP;
-                for (let loc in currentAP) {
-                    wearingArmour[loc] = currentAP[loc] + wearingArmour[loc];
-                }
-            }
-        }
-        for (let loc in wearingArmour) {
-            debuff = Math.max(debuff, wearingArmour[loc]);
-        }
-
-        if (debuff > 0) {
-            this.fields.slBonus += -debuff;
-            this.tooltips.add("slBonus", -debuff, game.i18n.localize("SHEET.SpellcasterArmourPenalties"));
-        }
+        applySpellcasterArmourPenalty(this.actor, this.fields, this.tooltips);
     }
 
     _getSubmissionData()

--- a/src/apps/roll-dialog/spellcaster-armour-penalty.js
+++ b/src/apps/roll-dialog/spellcaster-armour-penalty.js
@@ -1,0 +1,25 @@
+export function applySpellcasterArmourPenalty(actor, fields, tooltips) {
+    if (!game.settings.get("wfrp4e", "homebrew").spellcasterArmourPenalties) return;
+
+    let talentMetal = actor.has("Arcane Magic (Metal)", "talent");
+    let talentBeasts = actor.has("Arcane Magic (Beasts)", "talent");
+    let wearingArmour = { head: 0, lArm: 0, rArm: 0, lLeg: 0, rLeg: 0, body: 0 };
+    let debuff = 0;
+
+    for (let a of actor.itemTags["armour"].filter(i => i.isEquipped)) {
+        if ((a.system.isMetal && !talentMetal) || (a.system.isLeather && !talentBeasts)) {
+            const currentAP = a.system.currentAP;
+            for (let loc in currentAP) {
+                wearingArmour[loc] += currentAP[loc];
+            }
+        }
+    }
+    for (let loc in wearingArmour) {
+        debuff = Math.max(debuff, wearingArmour[loc]);
+    }
+
+    if (debuff > 0) {
+        fields.slBonus += -debuff;
+        tooltips.add("slBonus", -debuff, game.i18n.localize("SHEET.SpellcasterArmourPenalties"));
+    }
+}

--- a/src/model/item/armour.js
+++ b/src/model/item/armour.js
@@ -114,6 +114,11 @@ export class ArmourModel extends PropertiesMixin(EquippableItemModel) {
     return ["plate", "mail", "otherMetal", "gromril"].includes(this.armorType.value)
   }
 
+  get isLeather()
+  {
+    return ["softLeather", "boiledLeather"].includes(this.armorType.value)
+  }
+
   get protects() {
     let protects = {}
     for (let loc in this.AP) {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -109,6 +109,8 @@
     "SETTINGS.ExtendedTestsHint" : "Rolling a +/- 0 on Extended Tests results in a +1/-1 respectively (p155).",
     "SETTINGS.ChannelingNegativeSL": "Channeling magic and Negative SL",
     "SETTINGS.ChannelingNegativeSLHint": "Rolling a negative SL on channeling results in a +0, ensuring no progress is taken from the channeling attempt.",
+    "SETTINGS.SpellcasterArmourPenalties": "Spellcaster Armour Penalties",
+    "SETTINGS.SpellcasterArmourPenaltiesHint": "Spellcasters wearing metal or leather armour suffer –1 SL per AP on the most-covered location when Casting or Channelling (Repelling the Winds, CB p.237). Casters with Arcane Magic (Metal) or Arcane Magic (Beasts) are exempt from the respective armour type.",
     "SETTINGS.TestDialogAutoPopulate" : "Test Dialog Auto Populate",
     "SETTINGS.TestDialogAutoPopulateHint" : "This setting automatically fills out information in the dialog for Tests. Some examples include: Wielding Defensive weapons automatically fills 'SL Bonus' in roll dialogs for melee weapons. This only occurs if it is not the actor's turn. Also when wieldirg an Accurate or (Im)precise Weapon (on the actor's turn).",
     "SETTINGS.TestDialogDefaultDifficulty" : "Default Non-Combat Test Difficulty",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -293,6 +293,7 @@
     "SHEET.RangedWeaponHeader" : "Ranged Weapon(s)",
     "SHEET.ArmourAP" : "Armour AP",
     "SHEET.ArmourPenalties" : "Armour Penalties",
+    "SHEET.SpellcasterArmourPenalties" : "Spellcaster wearing armour Penalties",
     "SHEET.ShieldAP" : "Shield AP",
     "SHEET.TB" : "Toughness Bonus",
     "SHEET.CreateItem" : "Create Item",


### PR DESCRIPTION
Implements Repelling the Winds, CB p.237 rules.
Works with Archives 3 armour.
Allows turning this off as homebrew rule to preserve existing behaviour.
On by default.