### PR TITLE
feat: stack quantity when purchasing duplicate items from market

### DIFF
--- a/src/model/message/posted-item.js
+++ b/src/model/message/posted-item.js
@@ -147,7 +147,7 @@ export class PostedItemMessageModel extends WarhammerMessageModel {
    */
   static async create(item, quantity, mergeData = {}) 
   {
-    if (quantity == undefined && (item.system.isPhysical))
+    if (quantity === undefined && (item.system.isPhysical))
     {
       quantity = await ValueDialog.create({title : game.i18n.localize("DIALOG.PostQuantity"), text : game.i18n.localize("DIALOG.PostQuantityContent")}) || undefined
     }

--- a/src/sheets/actor/base.js
+++ b/src/sheets/actor/base.js
@@ -373,6 +373,35 @@ export default class BaseWFRP4eActorSheet extends WarhammerActorSheetV2
         }
       },
       {
+        name: "Buy More",
+        icon: '<i class="fas fa-shopping-cart"></i>',
+        condition: li => {
+          let uuid = li.dataset.uuid || getParent(li, "[data-uuid]").dataset.uuid;
+          if (uuid && !uuid.includes("Compendium"))
+          {
+            let doc = fromUuidSync(uuid);
+            return doc?.documentName == "Item" && doc.system.isPhysical && !doc.system.isMoney;
+          }
+          else return false;
+        },
+        callback: async li =>
+        {
+          let uuid = li.dataset.uuid || getParent(li, "[data-uuid]").dataset.uuid;
+          const document = await fromUuid(uuid);
+          const sourceId = document._stats?.compendiumSource;
+          if (sourceId)
+          {
+            const sourceItem = await fromUuid(sourceId);
+            if (sourceItem)
+            {
+              sourceItem.postItem(null);
+              return;
+            }
+          }
+          document.postItem(null);
+        }
+      },
+      {
         name: "Duplicate",
         icon: '<i class="fa-solid fa-copy"></i>',
         condition: li => {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1144,6 +1144,7 @@
     "MARKET.NotifyNoActor": "No Character is selected or associated with the current user",
     "MARKET.NotifyUserMustBePlayer": "Must be a player to click on PAY",
     "MARKET.ItemAdded" : "{item} added to {actor}",
+    "MARKET.ItemAppended" : "{actor} now has {quantity} {item}s",
     "Post Quantity" : "Post Quantity",
 
     "WFRP4E.TrappingType.Weapon" : "Weapons",


### PR DESCRIPTION
When an actor buys a posted item they already own (same name and compendium source), increase the existing item's quantity instead of creating a duplicate. 
Adds MARKET.ItemAppended notification to distinguish the two cases.