### PR TITLE
feat: include product name in payment confirmation message

### DIFF
--- a/src/model/message/pay.js
+++ b/src/model/message/pay.js
@@ -93,15 +93,16 @@ export class PayMessageModel extends WarhammerMessageModel {
 
   static async _onPay(ev, target)
   {
-      if (!game.user.isGM) 
+      let payString = this.product ? `${this.payString},${this.product}` : this.payString;
+      if (!game.user.isGM)
       {
-        game.wfrp4e.market.handlePlayerPayment({payString : this.payString})
-      } 
-      else 
+        game.wfrp4e.market.handlePlayerPayment({payString})
+      }
+      else
       {
         for(let actor of targetsWithFallback())
         {
-          game.wfrp4e.market.handlePlayerPayment({payString: this.payString, target : actor})
+          game.wfrp4e.market.handlePlayerPayment({payString, target : actor})
         }
       }
   }

--- a/src/model/message/posted-item.js
+++ b/src/model/message/posted-item.js
@@ -82,7 +82,9 @@ export class PostedItemMessageModel extends WarhammerMessageModel {
   static async _onPay(ev, target)
   {
     
-    let paid = await game.wfrp4e.market.handlePlayerPayment({payString : game.wfrp4e.market.amountToString(this.itemData.system.price), itemData : this.itemData});
+    let qty = this.itemData.system.quantity.value;
+    let product = qty > 1 ? `${this.itemData.name} x${qty}` : this.itemData.name;
+    let paid = await game.wfrp4e.market.handlePlayerPayment({payString : `${game.wfrp4e.market.amountToString(this.itemData.system.price)},${product}`, itemData : this.itemData});
     for(let actor of paid)
     {
       await actor.createEmbeddedDocuments("Item", [this.itemData], {fromMessage: this.parent.id})

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1128,7 +1128,7 @@
     "MARKET.For": "for",
     "MARKET.ReceivedBy" : "Received by:",
     "MARKET.MoneyTransactionWrongCommand" : "Wrong syntax. Please format your command like in the following examples:",
-    "MARKET.PayCommandExample" : "/pay 3gc2bp<br>/pay 450bp<br>/pay 2ss12bp4gc<br>/pay 1gc John<br>/pay 12ss Kastor Lieberung",
+    "MARKET.PayCommandExample" : "/pay 3gc2bp<br>/pay 450bp<br>/pay 2ss12bp4gc<br>/pay 1gc for=Room and Board<br>/pay 12ss for=Lodging target=Kastor Lieberung",
     "MARKET.CreditCommandExample" : "/credit 3gc2bp<br>/credit 450bp each<br>/credit 2ss12bp4gc split<br>/credit 2ss John<br>/credit 12gc Kastor Lieberung",
     "MARKET.CantFindMoneyItems" : "Error. Can't find the money items (GC/BP/SS) in the character inventory.",
     "MARKET.NotEnoughMoney" : "This character does not have enough money to pay for this.<br>",


### PR DESCRIPTION
When paying for a posted chat item or responding to a /pay card with a product label, the confirmation message now shows "Purchased product: X" above the payment summary. 
Also fixes /pay command examples to use the correct for= and target= named-arg syntax.
<img width="580" height="658" alt="image" src="https://github.com/user-attachments/assets/b8a1e751-efdf-4d50-baf1-ef1f9c2f846c" />