### PR TITLE
fix: include dice damage in spell damage application

### DIFF
--- a/src/model/message/magic.js
+++ b/src/model/message/magic.js
@@ -221,7 +221,7 @@ export class MagicUseMessageModel extends WFRPEffectMessageMixin(WarhammerMessag
       let damage = item.system.Damage;
 
       return { // If damage exists, add SL (if any), otherwise, stick with 0
-        damage: test?.result.damage || (damage > 0 ? damage + (testData.SL || 0) : damage),
+        damage: test?.result.damage ? (test.result.damage + (test.result.additionalDamage || 0)) : (damage > 0 ? damage + (testData.SL || 0) : damage),
         range,
         duration,
         target,


### PR DESCRIPTION
Fixes: #2778 
additionalDamage (from the Dice box) was calculated and shown in the breakdown but never added to testData.damage, so only the formula component was applied when clicking Apply Damage on the spell card.
<img width="584" height="1470" alt="image" src="https://github.com/user-attachments/assets/04701220-071e-4973-a291-12a4a5000db6" />
