### PR TITLE
feat: auto-engage on melee attack, disengage on death/flee

### DIFF
--- a/src/hooks/combat.js
+++ b/src/hooks/combat.js
@@ -1,5 +1,6 @@
 import CombatHelpersWFRP from "../system/combat.js"
 import WFRP_Utility from "../system/utility-wfrp4e.js"
+import EngagementTracker from "../system/engagement.js"
 
 export default function() {
 
@@ -59,6 +60,62 @@ export default function() {
     let navigation = document.querySelector(selector);
     navigation.classList.add(className)
   }
+
+  // Auto-engage both combatants when a melee weapon or trait test has targets
+  function onMeleeAttackRolled(test) {
+    if (!game.user.isUniqueGM) return;
+    if (!game.combat?.active) return;
+    if (!game.settings.get("wfrp4e", "autoEngaged")) return;
+    if (test.item.attackType != "melee") return;
+
+    let attacker = test.actor;
+    let targets = test.targetTokens.map(t => t?.actor).filter(Boolean);
+    for (let target of targets) {
+      EngagementTracker.engage(attacker, target);
+    }
+  }
+
+  Hooks.on("wfrp4e:rollWeaponTest", onMeleeAttackRolled);
+  Hooks.on("wfrp4e:rollTraitTest", onMeleeAttackRolled);
+
+  // Disengage when a character becomes dead or unconscious
+  Hooks.on("createActiveEffect", (effect, options, userId) => {
+    if (!game.user.isUniqueGM) return;
+    if (EngagementTracker._clearing) return;
+    if (!game.combat?.active) return;
+    if (!game.settings.get("wfrp4e", "autoEngaged")) return;
+
+    let actor = effect.parent;
+    if (!(actor instanceof Actor)) return;
+    if (effect.statuses.has("dead") || effect.statuses.has("unconscious")) {
+      EngagementTracker.disengage(actor);
+    }
+  });
+
+  // Detect manual removal of the Engaged condition and run cascade check
+  Hooks.on("deleteActiveEffect", (effect, options, userId) => {
+    if (!game.user.isUniqueGM) return;
+    if (EngagementTracker._clearing) return;
+    if (!game.combat?.active) return;
+    if (!game.settings.get("wfrp4e", "autoEngaged")) return;
+
+    let actor = effect.parent;
+    if (!(actor instanceof Actor)) return;
+    if (effect.statuses.has("engaged")) {
+      // suppressConditionRemoval=true because the effect is already being deleted.
+      // disengage will no-op if this actor is already being processed (_disengaging guard).
+      EngagementTracker.disengage(actor, {suppressConditionRemoval: true});
+    }
+  });
+
+  // Trigger disengage when the "Flee from Harm" group advantage action is used
+  Hooks.on("wfrp4e:useGroupAdvantageAction", (actor, action) => {
+    if (!game.user.isUniqueGM) return;
+    if (!game.combat?.active) return;
+    if (!game.settings.get("wfrp4e", "autoEngaged")) return;
+    if (action.name !== "Flee from Harm") return;
+    EngagementTracker.flee(actor);
+  });
 
   Hooks.on("renderCombatTracker", (app, html, options) => {
     warhammer.utility.replacePopoutTokens(app.element); // Combat tracker shows tokens, replace popout versions with normal

--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -366,6 +366,15 @@ export default function() {
       type: Boolean
     });
 
+    game.settings.register("wfrp4e", "autoEngaged", {
+      name: "SETTINGS.AutoEngaged",
+      hint: "SETTINGS.AutoEngagedHint",
+      scope: "world",
+      config: true,
+      default: false,
+      type: Boolean
+    });
+
     game.settings.register("wfrp4e", "tables", {
       scope: "world",
       config: false,

--- a/src/sheets/actor/base.js
+++ b/src/sheets/actor/base.js
@@ -645,6 +645,8 @@ export default class BaseWFRP4eActorSheet extends WarhammerActorSheetV2
                 this.actor.setupCharacteristic(action.test.value, {appendTitle : ` - ${action.name}`}).then(test => test.roll())
               }
             }
+
+            Hooks.call("wfrp4e:useGroupAdvantageAction", this.actor, action)
           }
       }
       else 

--- a/src/system/combat.js
+++ b/src/system/combat.js
@@ -1,5 +1,6 @@
 import WFRP_Audio from "./audio-wfrp4e.js";
 import WFRP_Utility from "./utility-wfrp4e.js";
+import EngagementTracker from "./engagement.js";
 
 export default class CombatHelpersWFRP {
 
@@ -7,7 +8,7 @@ export default class CombatHelpersWFRP {
     static registerHelpers() 
     {
         CombatHelpers.startCombat = [CombatHelpersWFRP.checkFearTerror];
-        CombatHelpers.endCombat = [CombatHelpersWFRP.clearCombatantAdvantage, CombatHelpersWFRP.checkCorruption, CombatHelpersWFRP.checkInfection, CombatHelpersWFRP.checkDiseases];
+        CombatHelpers.endCombat = [CombatHelpersWFRP.clearCombatantAdvantage, CombatHelpersWFRP.checkCorruption, CombatHelpersWFRP.checkInfection, CombatHelpersWFRP.checkDiseases, EngagementTracker.clearAll.bind(EngagementTracker)];
         CombatHelpers.startTurn = [CombatHelpersWFRP.checkStartTurnConditions];
         CombatHelpers.endTurn = [CombatHelpersWFRP.checkEndTurnConditions];
         CombatHelpers.endRound = [CombatHelpersWFRP.checkEndRoundConditions, CombatHelpersWFRP.fearReminders];

--- a/src/system/engagement.js
+++ b/src/system/engagement.js
@@ -1,0 +1,123 @@
+
+export default class EngagementTracker {
+
+    static _clearing = false;
+    static _disengaging = new Set();
+
+    static get setting() {
+        return game.settings.get("wfrp4e", "autoEngaged");
+    }
+
+    static get engagements() {
+        return game.combat?.getFlag("wfrp4e", "engagements") || {};
+    }
+
+    /**
+     * Mark two actors as engaged with each other and apply the Engaged condition to both.
+     */
+    static async engage(attacker, defender) {
+        if (!this.setting || !game.combat?.active) return;
+
+        let engagements = foundry.utils.deepClone(this.engagements);
+
+        if (!engagements[attacker.id]) engagements[attacker.id] = [];
+        if (!engagements[defender.id]) engagements[defender.id] = [];
+
+        if (!engagements[attacker.id].includes(defender.id))
+            engagements[attacker.id].push(defender.id);
+        if (!engagements[defender.id].includes(attacker.id))
+            engagements[defender.id].push(attacker.id);
+
+        await game.combat.setFlag("wfrp4e", "engagements", engagements);
+
+        if (!attacker.hasCondition("engaged"))
+            await attacker.addCondition("engaged");
+        if (!defender.hasCondition("engaged"))
+            await defender.addCondition("engaged");
+    }
+
+    /**
+     * Remove an actor from all engagement tracking and cascade:
+     * any former partner left with no remaining engagements also loses Engaged.
+     *
+     * @param {Actor} actor
+     * @param {object} options
+     * @param {boolean} options.suppressConditionRemoval  True when the Engaged condition is already
+     *   being deleted (e.g. called from deleteActiveEffect), so we skip the removeCondition call.
+     */
+    static async disengage(actor, {suppressConditionRemoval = false} = {}) {
+        if (!this.setting || !game.combat?.active) return;
+        if (this._disengaging.has(actor.id)) return;
+
+        this._disengaging.add(actor.id);
+        try {
+            let engagements = foundry.utils.deepClone(this.engagements);
+            let partners = engagements[actor.id] || [];
+
+            // Compute filtered partner lists upfront — used for both flag update and cascade check.
+            let filteredLists = {};
+            for (let partnerId of partners) {
+                filteredLists[partnerId] = (engagements[partnerId] || []).filter(id => id != actor.id);
+            }
+
+            // Update flags: explicitly delete actor's entry and overwrite partner arrays.
+            // setFlag merges into the existing object — without the -=key prefix the deleted
+            // actor entry would be preserved server-side, causing stale engagements.
+            let flagUpdate = {};
+            flagUpdate[`flags.wfrp4e.engagements.-=${actor.id}`] = null;
+            for (let [partnerId, filtered] of Object.entries(filteredLists)) {
+                flagUpdate[`flags.wfrp4e.engagements.${partnerId}`] = filtered;
+            }
+            await game.combat.update(flagUpdate);
+
+            if (!suppressConditionRemoval && actor.hasCondition("engaged")) {
+                await actor.removeCondition("engaged");
+            }
+
+            // Partners with no remaining engagements lose the condition
+            for (let partnerId of partners) {
+                let partner = game.actors.get(partnerId);
+                if (!partner) continue;
+                if ((filteredLists[partnerId]?.length ?? 0) == 0 && partner.hasCondition("engaged")) {
+                    this._disengaging.add(partner.id);
+                    try {
+                        await partner.removeCondition("engaged");
+                    } finally {
+                        this._disengaging.delete(partner.id);
+                    }
+                }
+            }
+        } finally {
+            this._disengaging.delete(actor.id);
+        }
+    }
+
+    /**
+     * Flee: disengage the actor (same cascade logic as disengage).
+     */
+    static async flee(actor) {
+        await this.disengage(actor);
+    }
+
+    /**
+     * Called when combat ends — strip all tracked Engaged conditions and clear flags.
+     * Receives the combat document from CombatHelpers.endCombat.
+     */
+    static async clearAll(combat) {
+        if (!game.settings.get("wfrp4e", "autoEngaged")) return;
+
+        EngagementTracker._clearing = true;
+        try {
+            let engagements = combat.getFlag("wfrp4e", "engagements") || {};
+            for (let actorId of Object.keys(engagements)) {
+                let actor = game.actors.get(actorId);
+                if (actor?.hasCondition("engaged")) {
+                    await actor.removeCondition("engaged");
+                }
+            }
+            await combat.unsetFlag("wfrp4e", "engagements");
+        } finally {
+            EngagementTracker._clearing = false;
+        }
+    }
+}

--- a/src/wfrp4e.js
+++ b/src/wfrp4e.js
@@ -21,6 +21,7 @@ import Migration from "./system/migrations.js";
 import HomebrewSettings from "./apps/homebrew-settings.js"
 import CareerSelector from "./apps/career-selector.js"
 import TagManager from "./system/tag-manager.js";
+import EngagementTracker from "./system/engagement.js";
 import ItemProperties from "./apps/item-properties.js"
 import TestWFRP from "./system/rolls/test-wfrp4e.js";
 import CharacteristicTest from "./system/rolls/characteristic-test.js";
@@ -238,7 +239,8 @@ Hooks.once("init", function () {
     migration: Migration,
     opposedHandler: OpposedHandler,
     tags : new TagManager(),
-    trade : new TradeManager()
+    trade : new TradeManager(),
+    engagement : EngagementTracker
   }
 
   CombatHelpersWFRP.registerHelpers();

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -137,6 +137,8 @@
     "SETTINGS.UIAShieldsHint" : "Change the Shield property as specified in Up In Arms page 90",
     "SETTINGS.UIABleeding" : "Up In Arms Bleeding Condition",
     "SETTINGS.UIABleedingHint" : "Change Bleeding condition as specified in Up In Arms page 80",
+    "SETTINGS.AutoEngaged" : "Auto Engaged Condition",
+    "SETTINGS.AutoEngagedHint" : "Automatically apply the Engaged condition when a melee attack is made during combat. Characters disengage when they die, fall unconscious, or flee.",
     "SETTINGS.WeaponLength" : "Weapon Length",
     "SETTINGS.WeaponLengthHint" : "Use weapon length to apply modifiers as described by the rule on page 297.",
     "SETTINGS.SoundEffects" : "Sound Effect Path",


### PR DESCRIPTION
My swing at auto-engage in melee for your consideration.
Track attacks so ex if PC1 and PC2 both attack NPC1 and kill it they both loose Engaged.
Works only when in Combat.
Isn't that complex but I understand if you don't want this load for a small feature.

- New EngagementTracker (engagement.js): tracks bidirectional engagements in combat flags; engage/disengage/flee/clearAll
- Apply Engaged to both sides on any melee weapon or trait test
- Cascade disengage: partners with no remaining engagements lose Engaged
- Disengage on dead/unconscious condition; Flee from Harm group action
- _disengaging guard prevents re-entrant deleteActiveEffect loops
- Flag updates use -=key deletion syntax to avoid Foundry merge bug
- clearAll strips all Engaged conditions when combat ends
- autoEngaged world setting to opt in/out