### PR TITLE
feat: apply -10 ranged penalty when shooter moved this round

### DIFF
--- a/src/apps/roll-dialog/attack-dialog.js
+++ b/src/apps/roll-dialog/attack-dialog.js
@@ -10,6 +10,13 @@ export default class AttackDialog extends SkillDialog
     computeFields()
     {
         super.computeFields();
+        if (this.item.attackType == "ranged" && game.combat?.active) {
+            let combatant = game.combat.combatants.find(c => c.actor?.id == this.actor.id);
+            if (combatant?.token?.movementHistory?.length > 0) {
+                this.fields.modifier -= 10;
+                this.tooltips.add("modifier", -10, game.i18n.localize("CHAT.TestModifiers.MovedThisRound"));
+            }
+        }
         if (!["roll", "none"].includes(this.fields.hitLocation))
         {
             this.fields.modifier -= 20;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -952,6 +952,7 @@
     "CHAT.TestModifiers.ShootingSizeModifier" : "Shooting at a {size} target.",
     "CHAT.TestModifiers.AttackerMountLarger" : "Bonus for attacking from a larger mount.",
     "CHAT.TestModifiers.DefenderMountLarger" : "Penalty for attacking the rider of a larger mount.",
+    "CHAT.TestModifiers.MovedThisRound" : "Shooting on a Round where you also use your Move",
     "CHAT.TestModifiers.SlowDefend" : "Attacker has Slow Weapon",
     "CHAT.TestModifiers.WrapDefend" : "Attacker has Wrap Weapon",
     "CHAT.TestModifiers.IgnoreDefenderMountLarger" : "Ignored penalty to attack rider because of weapon's reach (Up in Arms).",


### PR DESCRIPTION
Implements the -10 penalty to ranged when character moved. CB p161
Modifier shown as 'Shooting on a Round where you also use your Move'.