### PR TITLE
Fix 2767

### DIFF
--- a/src/system/opposed-test.js
+++ b/src/system/opposed-test.js
@@ -92,7 +92,7 @@ export default class OpposedTest {
       let attackerReach = this.attackerTest.item.reachNum;
       let defenderReach = this.defenderTest.item.reachNum;
       if (defenderReach > attackerReach && !this.attackerTest.result.infighter) {
-        modifiers.message.push(game.i18n.format(game.i18n.localize('CHAT.TestModifiers.WeaponLength'), { defender: this.defenderTest.actor.prototypeToken.name, attacker: this.attackerTest.actor.prototypeToken.name }))
+        modifiers.message.push(game.i18n.format('CHAT.TestModifiers.WeaponLength', { defender: this.defenderTest.actor.prototypeToken.name, attacker: this.attackerTest.actor.prototypeToken.name }))
         modifiers.attacker.target += -10;
       }
     }

--- a/src/system/rolls/weapon-test.js
+++ b/src/system/rolls/weapon-test.js
@@ -9,7 +9,7 @@ export default class WeaponTest extends AttackTest {
       return
     this.preData.ammoId = data.ammo?.id // TODO vehicle shit
     this.preData.charging = data.charging || false;
-    this.preData.infighter = data.infighter || !!actor?.has(game.i18n.localize("NAME.Infighter"), "talent"); // I don't like this but it's really awkward to implement with scripts
+    this.preData.infighter = data.infighter || !!this.actor?.has(game.i18n.localize("NAME.Infighter"), "talent"); // I don't like this but it's really awkward to implement with scripts
     this.preData.resolute = data.resolute || 0;
     this.preData.dualWielding = data.dualWielding || false;
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1338,7 +1338,7 @@
     "NAME.TraitRanged" : "Ranged",
     "NAME.TraitArmour" : "Armour",
     "NAME.Unstable" : "Unstable",
-    "NAME.Infighter" : "In–fighter",
+    "NAME.Infighter" : "In-fighter",
     "NAME.DeadeyeShot" : "Deadeye Shot",
     "NAME.StrikeToStun" : "Strike to Stun",
     "NAME.Arcane" : "Arcane",


### PR DESCRIPTION
Fixes: #2767 
This was so annoying there were 3 issues.
- NAME.Infighter localization had an en dash (U+2013) instead of a
  regular hyphen, so actor.has() never matched the talent name
- WeaponTest constructor used the `actor` parameter which is undefined;
  switched to `this.actor` (populated by super() from data.actor)
- Weapon length chat message used game.i18n.format(game.i18n.localize())
  double-wrapping; Foundry v14 doesn't substitute {placeholders} when
  the input is a pre-translated string rather than a key