### PR TITLE
Fix /credit command ignoring target parameter.

### DIFF
--- a/src/model/message/credit.js
+++ b/src/model/message/credit.js
@@ -50,7 +50,7 @@ export class CreditMessageModel extends WarhammerMessageModel {
           }
         }
         // Default choice, display chat card
-        this.createCreditMessage(amount, mode, {split : Number(split) ,reason, player: target});
+        this.createCreditMessage(amount, mode, {split : Number(split) ,reason, target});
       }
       return false;
   }


### PR DESCRIPTION
Fixes an issue where the /credit command would ignore the target parameter, resulting in it sending the message to all connected players rather than just the intended target.