### PR TITLE
calculate spell cost

### DIFF
--- a/src/system/advancement.js
+++ b/src/system/advancement.js
@@ -226,33 +226,33 @@ export default class Advancement
     }
 
 
-    if (["slaanesh", "tzeentch", "nurgle", "undivided"].includes(spell.lore.value[0]))
+    if (["slaanesh", "tzeentch", "nurgle", "undivided"].includes(spell.lore.value))
       return 0
 
-    if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty"))
+    if (spell.lore.value == "petty" || spell.lore.value == game.i18n.localize("WFRP4E.MagicLores.petty"))
       bonus = actor.characteristics.wp.bonus
     else 
       bonus = actor.characteristics.int.bonus
 
-    if (spell.lore.value[0] != "petty" && spell.lore.value[0] != game.i18n.localize("WFRP4E.MagicLores.petty"))
+    if (spell.lore.value != "petty" && spell.lore.value != game.i18n.localize("WFRP4E.MagicLores.petty"))
     {
-      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value[0] == spell.lore.value[0] && i.memorized.value).length;
+      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value == spell.lore.value && i.memorized.value).length;
     }
-    else if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty"))
+    else if (spell.lore.value == "petty" || spell.lore.value == game.i18n.localize("WFRP4E.MagicLores.petty"))
     {
-      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value[0] == spell.lore.value[0]).length;
+      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value == spell.lore.value).length;
       if (currentlyKnown < bonus)
         return 0 // First WPB petty spells are free
     }
 
     let costKey = currentlyKnown
-    if (spell.lore.value[0] != "petty" && spell.lore.value[0] != game.i18n.localize("WFRP4E.MagicLores.petty"))
+    if (spell.lore.value != "petty" && spell.lore.value != game.i18n.localize("WFRP4E.MagicLores.petty"))
       costKey-- // Not sure if this is right, but arcane and petty seem to scale different per the example given
 
     cost = Math.ceil(Math.max(1, costKey) / bonus) * 100
 
-    if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty")) cost *= 0.5 // Petty costs 50 each instead of 100
-    else if (spell.lore.value[0] == "high" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.high")) cost *= 2 // High costs 200 each instead of 100
+    if (spell.lore.value == "petty" || spell.lore.value == game.i18n.localize("WFRP4E.MagicLores.petty")) cost *= 0.5 // Petty costs 50 each instead of 100
+    else if (spell.lore.value == "high" || spell.lore.value == game.i18n.localize("WFRP4E.MagicLores.high")) cost *= 2 // High costs 200 each instead of 100
 
     return cost
   }

--- a/src/system/advancement.js
+++ b/src/system/advancement.js
@@ -226,32 +226,32 @@ export default class Advancement
     }
 
 
-    if (["slaanesh", "tzeentch", "nurgle"].includes(spell.lore.value))
+    if (["slaanesh", "tzeentch", "nurgle", "undivided"].includes(spell.lore.value[0]))
       return 0
 
-    if (spell.lore.value == "petty" || spell.lore.value == game.i18n.localize("WFRP4E.MagicLores.petty"))
+    if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty"))
       bonus = actor.characteristics.wp.bonus
     else 
       bonus = actor.characteristics.int.bonus
 
-    if (spell.lore.value != "petty" && spell.lore.value != game.i18n.localize("WFRP4E.MagicLores.petty"))
+    if (spell.lore.value[0] != "petty" && spell.lore.value[0] != game.i18n.localize("WFRP4E.MagicLores.petty"))
     {
-      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value == spell.lore.value && i.memorized.value).length;
+      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value[0] == spell.lore.value[0] && i.memorized.value).length;
     }
-    else if (spell.lore.value == "petty" || spell.lore.value == game.i18n.localize("WFRP4E.MagicLores.petty"))
+    else if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty"))
     {
-      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value == spell.lore.value).length;
+      currentlyKnown = actor.itemTags["spell"].filter(i => i.lore.value[0] == spell.lore.value[0]).length;
       if (currentlyKnown < bonus)
         return 0 // First WPB petty spells are free
     }
 
     let costKey = currentlyKnown
-    if (spell.lore.value != "petty" && spell.lore.value != game.i18n.localize("WFRP4E.MagicLores.petty"))
+    if (spell.lore.value[0] != "petty" && spell.lore.value[0] != game.i18n.localize("WFRP4E.MagicLores.petty"))
       costKey-- // Not sure if this is right, but arcane and petty seem to scale different per th example given
 
     cost = Math.ceil(Math.max(1, costKey) / bonus) * 100
 
-    if (spell.lore.value == "petty" || spell.lore.value == game.i18n.localize("WFRP4E.MagicLores.petty")) cost *= 0.5 // Petty costs 50 each instead of 100
+    if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty")) cost *= 0.5 // Petty costs 50 each instead of 100
 
     return cost
   }

--- a/src/system/advancement.js
+++ b/src/system/advancement.js
@@ -247,11 +247,12 @@ export default class Advancement
 
     let costKey = currentlyKnown
     if (spell.lore.value[0] != "petty" && spell.lore.value[0] != game.i18n.localize("WFRP4E.MagicLores.petty"))
-      costKey-- // Not sure if this is right, but arcane and petty seem to scale different per th example given
+      costKey-- // Not sure if this is right, but arcane and petty seem to scale different per the example given
 
     cost = Math.ceil(Math.max(1, costKey) / bonus) * 100
 
     if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty")) cost *= 0.5 // Petty costs 50 each instead of 100
+    else if (spell.lore.value[0] == "high" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.high")) cost *= 2 // Petty costs 200 each instead of 100
 
     return cost
   }

--- a/src/system/advancement.js
+++ b/src/system/advancement.js
@@ -252,7 +252,7 @@ export default class Advancement
     cost = Math.ceil(Math.max(1, costKey) / bonus) * 100
 
     if (spell.lore.value[0] == "petty" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.petty")) cost *= 0.5 // Petty costs 50 each instead of 100
-    else if (spell.lore.value[0] == "high" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.high")) cost *= 2 // Petty costs 200 each instead of 100
+    else if (spell.lore.value[0] == "high" || spell.lore.value[0] == game.i18n.localize("WFRP4E.MagicLores.high")) cost *= 2 // High costs 200 each instead of 100
 
     return cost
   }


### PR DESCRIPTION
Fix for calculateSpellCost after the magic refactor.

Also added "undivided" to the chaos spell lores.
Note that the Enemy in Shadows spells have "Undivided" lore value, which should be changed to "undivided". Just remove the lore and add the Undivided lore again to fix it.