### PR TITLE
Fix Limit Equipped Weapons setting not doing anything.

### DIFF
--- a/src/model/item/weapon.js
+++ b/src/model/item/weapon.js
@@ -217,7 +217,7 @@ export class WeaponModel extends PropertiesMixin(EquippableItemModel) {
             let actor = this.parent.actor;
             let maxEquipPoints = actor.system.settings.equipPoints;
             let currentEquipPoints = actor.itemTypes.weapon.filter(i => i.system.isEquipped).reduce((points, weapon) => points + weapon.system.equipPoints, 0);
-            if (currentEquipPoints + this.equipPoints > maxEquipPoints)
+            if (game.settings.get("wfrp4e", "limitEquippedWeapons") && currentEquipPoints + this.equipPoints > maxEquipPoints)
             {
                 ui.notifications.error("ErrorLimitedWeapons", {localize: true});
                 foundry.audio.AudioHelper.play({src: `${game.settings.get("wfrp4e", "soundPath")}no.wav`}, false);


### PR DESCRIPTION
Fixes the Limit Equipped Weapons setting.   

Before this fix, the Limit Equipped Weapons setting was ignored and treated as if always on.  Stopping a player from equipping both a Longbow and a melee weapon.

After this fix, it will now abide by the setting and allow the player to equip both a Longbow and a melee weapon if the setting is unchecked, or not if it is checked.