### PR TITLE
Using Warpstone

### DIFF
--- a/src/system/config-wfrp4e.js
+++ b/src/system/config-wfrp4e.js
@@ -1889,6 +1889,38 @@ WFRP4E.PrepareSystemItems = function() {
             img: "icons/svg/blind.svg",
             statuses: ["blind"],
             system: {}
+        },
+        "warpstone": {
+            name: game.i18n.localize("EFFECT.Warpstone"),
+            img: "icons/commodities/gems/gem-fragments-rough-green.webp",
+            statuses: ["warpstone"],
+            system: {
+                scriptData: [
+                    {
+                        label: "@effect.name",
+                        trigger: "dialog",
+                        script: `args.fields.malignantInfluence = true`,
+                        options: {
+                            hideScript: "return args.skill?.name != `${game.i18n.localize(\"NAME.Language\")} (${game.i18n.localize(\"SPEC.Magick\")})` && !args.skill?.name.includes(game.i18n.localize(\"NAME.Channelling\")) && args.type != \"cast\" && args.type != \"channelling\"",
+                            activateScript: `return args.type == "cast" || args.type == "channelling"`,
+                            submissionScript: "args.context.warpstone = true"
+                        }
+                    },
+                    {
+                        label: "Warpstone Effects",
+                        trigger: "rollTest",
+                        script: "if ( args.test.options.warpstone ) {\n   let dispel = args.test.result.dispel?.SL ?? 0\n   args.test.result.other.push(\"Consuming warpstone is a @Corruption[Major]{Major Exposure to Corruption}.\")\n   if ( !args.test.fortuneUsed.SL ) {\n     args.test.result.SL = args.test.result.SL * 2 - dispel\n     }  \n}"
+                    },
+                    {
+                        label: "Overcasts",
+                        trigger: "rollCastTest",
+                        script: "if ( args.test.options.warpstone ) {\n  if (!game.settings.get(\"wfrp4e\", \"useWoMOvercast\")) {\n     args.test.result.overcast.total = Math.max(0, Math.floor((args.test.result.SL - args.test.spell.cn.value + Math.min(args.test.spell.cn.value, args.test.preData.itemData.system.cn.SL))/2))\n     args.test.result.overcast.available = args.test.result.overcast.total\n     if (args.test.item.Damage) { args.test.result.damage = Number(args.test.result.SL) + Number(args.test.item.Damage) }\n     if (args.test.result.SL - args.test.spell.cn.value >= 0) {\n        args.test.result.castOutcome = \"success\"\n        args.test.result.description = game.i18n.localize(\"ROLL.CastingSuccess\")\n        }\n     } else {\n        args.test.result.overcast.total = Math.max(0, args.test.result.SL - args.test.spell.cn.value + Math.min(args.test.spell.cn.value, args.test.preData.itemData.system.cn.SL))\n        args.test.result.overcast.available = args.test.result.overcast.total\n        args.test.result.overcast.originalSL = args.test.result.SL\n        if (args.test.result.SL - args.test.spell.cn.value >= 0) {\n          args.test.result.castOutcome = \"success\"\n          args.test.result.description = game.i18n.localize(\"ROLL.CastingSuccess\")\n          }\n      }\n}"
+                    }
+                ]
+            },
+			duration: {
+			    expiry: "turnEnd"
+            }
         }
     })
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1844,6 +1844,7 @@
     "EFFECT.DualWielder": "Dual Wielder",
     "EFFECT.ConsumeAlcohol": "Consume Alcohol",
     "EFFECT.MarienburghersCourage": "Marienburgher's Courage",
+    "EFFECT.Warpstone": "Using Warpstone",
     "EFFECT.TestsRelatedToHearing": "Tests related to hearing",
     "EFFECT.TestsRelatedToMovementOfAnyKind": "Tests related to movement of any kind",
     "EFFECT.TestsRelatedToSight": "Tests related to sight",


### PR DESCRIPTION
This PR adds Using Warpstone system effect as described in CRB p.238 and WoM p.22.

The effects checks automatically the Malignant Influence box and adds a roll dialog choice, so it can be unchecked in case of forgetting to remove the effect from a previous round.
It is shown in all Language (Magick) and Channelling rolls, and activated if it is a casting or channelling roll.
Adds a button to roll for a Major Exposure to Corruption in the chat card (CRB p.183).

It takes into account:

- Rolled SLs.
- Having Aethyric Attunement or Instinctive Diction talents.
- CRB and WoM rules for Overcasting.
- Extra damage for CRB rules.
- Re-Rolls and spending a Fortune point to add +1 SL.
- Dispels.
- Dhar rules (Enemy in Shadows) seem to work out-of-the-box.

Doesn't take into account:

- WoM rules for consuming warpstone.

The book isn't very precise about how SLs are doubled. I used this logic.

1. Rolled SLs + Success Bonuses are doubled.
2. Dispelled SLs from this total.
3. Spending fortune adds +1 SL to this total.

I know that expired effects aren't automatically removed (at least yet), but I added the expiration event "Turn End". This supposes consuming warpstone helps for a single casting or channelling roll.