### PR TITLE
fix: getHeaderToken throws on webm token images

### DIFF
--- a/src/model/message/test.js
+++ b/src/model/message/test.js
@@ -37,7 +37,7 @@ export class WFRPTestMessageModel extends WFRPEffectMessageMixin(WarhammerTestMe
 
       if (foundry.helpers.media.VideoHelper.hasVideoExtension(path))
       {
-        path = await game.video.createThumbnail(path, { width: 50, height: 50 }).then(img => chatOptions.flags.img = img)
+        path = await game.video.createThumbnail(path, { width: 50, height: 50 });
       }
 
       return path;


### PR DESCRIPTION
When player had token with webm animated image the test dialogues do no render.

> createThumbnail() resolves to the thumbnail data URL directly; the stray .then(img => chatOptions.flags.img = img) referenced an undefined chatOptions variable, throwing a ReferenceError whenever a token used a .webm texture.

Fixes:
<img width="598" height="120" alt="image" src="https://github.com/user-attachments/assets/508eea01-61fd-43f9-8c24-f38d047bf2e1" />
